### PR TITLE
Fixing Markdown Renderer

### DIFF
--- a/src/lib/renderers/markdownRenderer.js
+++ b/src/lib/renderers/markdownRenderer.js
@@ -8,7 +8,7 @@ export default function MarkdownRenderer(props) {
     // Markdown renderer with HTML rendering enabled.
     // rehypeRaw allows HTML rendering.
     // Convert <p> tags to simple <divs> using the components prop.
-    const rehypePlugins = props.colDef.dangerously_allow_html ? [rehypeRaw] : []
+    const rehypePlugins = props.colDef.dangerously_allow_code ? [rehypeRaw] : []
 
     return (
         <ReactMarkdown


### PR DESCRIPTION
Altering the `dangerously_allow*` component to be looking at `dangerously_allow_code` instead of `dangerously_allow_html`.