### PR TITLE
Refactor prop cleaning

### DIFF
--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -2,16 +2,21 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import * as evaluate from 'static-eval';
 import * as esprima from 'esprima';
-import {omit, equals, isEmpty} from 'ramda';
+import {equals, has, isEmpty, map, mapObjIndexed, omit} from 'ramda';
 import {
     propTypes as _propTypes,
     defaultProps as _defaultProps,
 } from '../components/AgGrid.react';
 import {
-    expressWarn,
-    gridFunctions,
-    columnFunctions,
-    replaceFunctions,
+    columnDangerousFunctions,
+    columnMaybeFunctions,
+    columnArrayNestedFunctions,
+    columnNestedFunctions,
+    gridMaybeFunctions,
+    gridOnlyFunctions,
+    gridColumnContainers,
+    gridNestedFunctions,
+    objOfFunctions,
 } from '../utils/functionVars';
 import debounce from '../utils/debounce';
 
@@ -37,28 +42,16 @@ const d3 = {...d3Format, ...d3Time, ...d3TimeFormat, ...d3Array};
 // Rate-limit for resizing columns when table div is resized
 const RESIZE_DEBOUNCE_MS = 200;
 
-const XSSMESSAGE =
-    'you are trying to use a dangerous element that could lead to XSS';
+const xssMessage = (context) => {
+    console.error(
+        context,
+        'Blocked a string that AG Grid would evaluate, to prevent XSS attacks. If you really want this, use dangerously_allow_code'
+    );
+};
 
 export default class DashAgGrid extends Component {
     constructor(props) {
         super(props);
-
-        const customComponents = window.dashAgGridComponentFunctions || {};
-        const _this = this;
-        const newComponents = {};
-        Object.keys(customComponents).forEach(function (key) {
-            newComponents[key] = _this.generateRenderer(customComponents[key]);
-        });
-
-        this.state = {
-            ...this.props.parentState,
-            components: {
-                rowMenu: this.generateRenderer(RowMenuRenderer),
-                markdown: this.generateRenderer(MarkdownRenderer),
-                ...newComponents,
-            },
-        };
 
         this.onGridReady = this.onGridReady.bind(this);
         this.onSelectionChanged = this.onSelectionChanged.bind(this);
@@ -72,20 +65,20 @@ export default class DashAgGrid extends Component {
             this.onDisplayedColumnsChanged.bind(this);
         this.onGridSizeChanged = this.onGridSizeChanged.bind(this);
         this.updateColumnWidths = this.updateColumnWidths.bind(this);
-        this.handleDynamicCellStyle = this.handleDynamicCellStyle.bind(this);
-        this.handleDynamicRowStyle = this.handleDynamicRowStyle.bind(this);
+        this.handleDynamicStyle = this.handleDynamicStyle.bind(this);
         this.generateRenderer = this.generateRenderer.bind(this);
         this.resetColumnState = this.resetColumnState.bind(this);
         this.exportDataAsCsv = this.exportDataAsCsv.bind(this);
         this.setSelection = this.setSelection.bind(this);
-        this.parseParamFunction = this.parseParamFunction.bind(this);
+        this.convertFunction = this.convertFunction.bind(this);
+        this.convertMaybeFunction = this.convertMaybeFunction.bind(this);
+        this.convertCol = this.convertCol.bind(this);
+        this.convertAllProps = this.convertAllProps.bind(this);
         this.buildArray = this.buildArray.bind(this);
-        this.fixCols = this.fixCols.bind(this);
         this.onAsyncTransactionsFlushed =
             this.onAsyncTransactionsFlushed.bind(this);
 
         // Additional Exposure
-        this.setUpCols = this.setUpCols.bind(this);
         this.selectAll = this.selectAll.bind(this);
         this.deselectAll = this.deselectAll.bind(this);
         this.autoSizeAllColumns = this.autoSizeAllColumns.bind(this);
@@ -93,16 +86,35 @@ export default class DashAgGrid extends Component {
         this.deleteSelectedRows = this.deleteSelectedRows.bind(this);
         this.rowTransaction = this.rowTransaction.bind(this);
         this.getRowData = this.getRowData.bind(this);
+        this.syncRowData = this.syncRowData.bind(this);
+        this.isDatasourceLoadedForInfiniteScrolling =
+            this.isDatasourceLoadedForInfiniteScrolling.bind(this);
+        this.getDatasource = this.getDatasource.bind(this);
+        this.applyRowTransaction = this.applyRowTransaction.bind(this);
+        this.parseFunction = this.parseFunction.bind(this);
+
+        const customComponents = window.dashAgGridComponentFunctions || {};
+        const newComponents = map(this.generateRenderer, customComponents);
+
+        this.state = {
+            ...this.props.parentState,
+            components: {
+                rowMenu: this.generateRenderer(RowMenuRenderer),
+                markdown: this.generateRenderer(MarkdownRenderer),
+                ...newComponents,
+            },
+        };
 
         this.selectionEventFired = false;
     }
 
     setSelection(selection) {
-        if (this.state.gridApi && selection) {
+        const {gridApi} = this.state;
+        if (gridApi && selection) {
             if (!selection.length) {
-                this.state.gridApi.deselectAll();
+                gridApi.deselectAll();
             } else {
-                this.state.gridApi.forEachNode((node) => {
+                gridApi.forEachNode((node) => {
                     const isSelected = selection.some(equals(node.data));
                     node.setSelected(isSelected);
                 });
@@ -110,286 +122,101 @@ export default class DashAgGrid extends Component {
         }
     }
 
-    fixCols(columnDef) {
-        const {dangerously_allow_code} = this.props;
+    convertFunction(func) {
+        // TODO: do we want this? ie allow the form `{function: <string>}` even when
+        // we're expecting just a string?
+        if (has('function', func)) {
+            return this.convertFunction(func.function);
+        }
 
-        const test = (target) => {
-            if (target in columnDef) {
-                if (!dangerously_allow_code && expressWarn.includes(target)) {
-                    if (typeof columnDef[target] !== 'function') {
-                        if (
-                            !Object.keys(columnDef[target]).includes('function')
-                        ) {
-                            columnDef[target] = () => '';
-                            console.error({
-                                field: columnDef.field || columnDef.headerName,
-                                message: XSSMESSAGE,
-                            });
-                        }
-                    }
-                }
-                if (typeof columnDef[target] !== 'function') {
-                    if (
-                        Object.keys(columnDef[target]).includes('function') &&
-                        !replaceFunctions.includes(target)
-                    ) {
-                        const newFunc = JSON.parse(
-                            JSON.stringify(columnDef[target].function)
-                        );
-                        columnDef[target] = (params) =>
-                            this.parseParamFunction(params, newFunc);
-                    }
-                }
-                if (replaceFunctions.includes(target)) {
-                    for (const [key, value] of Object.entries(
-                        columnDef[target]
-                    )) {
-                        if (typeof value !== 'function') {
-                            columnDef[target][key] = (params) =>
-                                this.parseParamFunction(params, value);
-                        }
-                    }
-                }
-                if (typeof columnDef[target] !== 'function') {
-                    for (var i in expressWarn) {
-                        var col = expressWarn[i];
-                        if (Object.keys(columnDef[target]).includes(col)) {
-                            if (!dangerously_allow_code) {
-                                if (
-                                    typeof columnDef[target][col] !== 'function'
-                                ) {
-                                    if (
-                                        !Object.keys(
-                                            columnDef[target][col]
-                                        ).includes('function')
-                                    ) {
-                                        columnDef[target][col] = () => '';
-                                        console.error({
-                                            field:
-                                                columnDef.field ||
-                                                columnDef.headerName,
-                                            message: XSSMESSAGE,
-                                        });
-                                    }
-                                }
-                            }
-                            if (typeof columnDef[target][col] !== 'function') {
-                                if (
-                                    Object.keys(
-                                        columnDef[target][col]
-                                    ).includes('function')
-                                ) {
-                                    const newFunc = JSON.parse(
-                                        JSON.stringify(
-                                            columnDef[target][col].function
-                                        )
-                                    );
-                                    columnDef[target][col] = (params) =>
-                                        this.parseParamFunction(
-                                            params,
-                                            newFunc
-                                        );
-                                }
-                            }
-                        }
-                    }
-                }
+        try {
+            if (typeof func !== 'string') {
+                throw new Error('tried to parse non-string as function', func);
             }
-            if ('headerComponentParams' in columnDef) {
-                if (target in columnDef.headerComponentParams) {
-                    if (
-                        !dangerously_allow_code &&
-                        expressWarn.includes(target)
-                    ) {
-                        if (
-                            typeof columnDef.headerComponentParams[target] !==
-                                'function' &&
-                            columnDef.headerComponentParams[target] !== ''
-                        ) {
-                            if (
-                                !Object.keys(
-                                    columnDef.headerComponentParams[target]
-                                ).includes('function')
-                            ) {
-                                columnDef.headerComponentParams[target] = '';
-                                console.error({
-                                    field:
-                                        columnDef.field || columnDef.headerName,
-                                    message: XSSMESSAGE,
-                                });
-                            }
-                        }
-                    }
-                    if (
-                        typeof columnDef.headerComponentParams[target] !==
-                        'function'
-                    ) {
-                        if (
-                            Object.keys(
-                                columnDef.headerComponentParams[target]
-                            ).includes('function') &&
-                            !replaceFunctions.includes(target)
-                        ) {
-                            const newFunc = JSON.parse(
-                                JSON.stringify(
-                                    columnDef.headerComponentParams[target]
-                                        .function
-                                )
-                            );
-                            columnDef.headerComponentParams[target] = (
-                                params
-                            ) => this.parseParamFunction(params, newFunc);
-                        }
-                    }
-                    if (replaceFunctions.includes(target)) {
-                        for (const [key, value] of Object.entries(
-                            columnDef.headerComponentParams[target]
-                        )) {
-                            if (typeof value !== 'function') {
-                                columnDef.headerComponentParams[target][key] = (
-                                    params
-                                ) => this.parseParamFunction(params, value);
-                            }
-                        }
-                    }
-                }
-            }
-            if ('headerGroupComponentParams' in columnDef) {
-                if (target in columnDef.headerGroupComponentParams) {
-                    if (
-                        !dangerously_allow_code &&
-                        expressWarn.includes(target)
-                    ) {
-                        if (
-                            typeof columnDef.headerGroupComponentParams[
-                                target
-                            ] !== 'function' &&
-                            columnDef.headerGroupComponentParams[target] !== ''
-                        ) {
-                            if (
-                                !Object.keys(
-                                    columnDef.headerGroupComponentParams[target]
-                                ).includes('function')
-                            ) {
-                                columnDef.headerGroupComponentParams[target] =
-                                    '';
-                                console.error({
-                                    field:
-                                        columnDef.field || columnDef.headerName,
-                                    message: XSSMESSAGE,
-                                });
-                            }
-                        }
-                    }
-                    if (
-                        typeof columnDef.headerGroupComponentParams[target] !==
-                        'function'
-                    ) {
-                        if (
-                            Object.keys(
-                                columnDef.headerGroupComponentParams[target]
-                            ).includes('function') &&
-                            !replaceFunctions.includes(target)
-                        ) {
-                            const newFunc = JSON.parse(
-                                JSON.stringify(
-                                    columnDef.headerGroupComponentParams[target]
-                                        .function
-                                )
-                            );
-                            columnDef.headerGroupComponentParams[target] = (
-                                params
-                            ) => this.parseParamFunction(params, newFunc);
-                        }
-                    }
-                    if (replaceFunctions.includes(target)) {
-                        for (const [key, value] of Object.entries(
-                            columnDef.headerGroupComponentParams[target]
-                        )) {
-                            if (typeof value !== 'function') {
-                                columnDef.headerGroupComponentParams[target][
-                                    key
-                                ] = (params) =>
-                                    this.parseParamFunction(params, value);
-                            }
-                        }
-                    }
-                }
-            }
-        };
-
-        columnFunctions.concat(expressWarn).map(test);
-
-        return columnDef;
+            return this.parseFunction(func);
+        } catch (err) {
+            console.log(err);
+        }
+        return '';
     }
 
-    setUpCols() {
-        const {columnDefs, setProps, defaultColDef, detailCellRendererParams} =
-            this.props;
-
-        const cleanOneCol = (col) => {
-            let colOut = this.fixCols(col);
-            if ('children' in colOut) {
-                colOut = {
-                    ...col,
-                    children: col.children.map(cleanOneCol),
-                };
-            }
-
-            if ('cellStyle' in colOut) {
-                if (
-                    Object.keys(colOut.cellStyle).includes('styleConditions') ||
-                    Object.keys(colOut.cellStyle).includes('defaultStyle')
-                ) {
-                    const cellStyle = JSON.parse(
-                        JSON.stringify(colOut.cellStyle)
-                    );
-                    colOut.cellStyle = (params) =>
-                        this.handleDynamicCellStyle({params, cellStyle});
-                }
-            }
-            return colOut;
-        };
-
-        if (columnDefs) {
-            setProps({
-                columnDefs: columnDefs.map((columnDef) => {
-                    const colDefOut = columnDef;
-                    return cleanOneCol(colDefOut);
-                }),
-            });
+    convertMaybeFunction(maybeFunc, stringsEvalContext) {
+        if (has('function', maybeFunc)) {
+            return this.convertFunction(maybeFunc.function);
         }
-        if (defaultColDef) {
-            setProps({
-                defaultColDef: cleanOneCol(defaultColDef),
-            });
+
+        if (
+            stringsEvalContext &&
+            typeof maybeFunc === 'string' &&
+            !this.props.dangerously_allow_code
+        ) {
+            xssMessage(stringsEvalContext);
+            return null;
         }
-        if (detailCellRendererParams) {
-            if ('detailGridOptions' in detailCellRendererParams) {
-                if (
-                    'columnDefs' in detailCellRendererParams.detailGridOptions
-                ) {
-                    detailCellRendererParams.detailGridOptions.columnDefs =
-                        detailCellRendererParams.detailGridOptions.columnDefs.map(
-                            (columnDef) => {
-                                const colDefOut = columnDef;
-                                return cleanOneCol(colDefOut);
-                            }
-                        );
-                    if (
-                        'defaultColDef' in
-                        detailCellRendererParams.detailGridOptions
-                    ) {
-                        detailCellRendererParams.detailGridOptions.defaultColDef =
-                            cleanOneCol(
-                                detailCellRendererParams.detailGridOptions
-                                    .defaultColDef
-                            );
-                    }
-                    setProps({detailCellRendererParams});
-                }
+        return maybeFunc;
+    }
+
+    convertCol(columnDef) {
+        const field = columnDef.field || columnDef.headerName;
+
+        return mapObjIndexed((value, target) => {
+            if (objOfFunctions[target]) {
+                return map(this.convertFunction, value);
             }
-        }
+            if (columnDangerousFunctions[target]) {
+                // the second argument tells convertMaybeFunction
+                // that a plain string is dangerous,
+                // and provides the context for error reporting
+                return this.convertMaybeFunction(value, {target, field});
+            }
+            if (columnMaybeFunctions[target]) {
+                return this.convertMaybeFunction(value);
+            }
+            if (columnNestedFunctions[target]) {
+                return this.convertCol(value);
+            }
+            if (columnArrayNestedFunctions[target]) {
+                return value.map(this.convertCol);
+            }
+            if (
+                target === 'cellStyle' &&
+                (has('styleConditions', value) || has('defaultStyle', value))
+            ) {
+                return this.handleDynamicStyle(value);
+            }
+            // not one of those categories - pass it straight through
+            return value;
+        }, columnDef);
+    }
+
+    convertAllProps(props) {
+        return mapObjIndexed((value, target) => {
+            if (target === 'columnDefs') {
+                return value.map(this.convertCol);
+            }
+            if (gridColumnContainers[target]) {
+                return this.convertCol(value);
+            }
+            if (gridNestedFunctions[target]) {
+                return this.convertAllProps(value);
+            }
+            if (target === 'getRowId') {
+                return this.convertFunction(value);
+            }
+            if (target === 'getRowStyle') {
+                return this.handleDynamicStyle(value);
+            }
+            if (objOfFunctions[target]) {
+                return map(this.convertFunction, value);
+            }
+            if (gridOnlyFunctions[target]) {
+                return this.convertFunction(value);
+            }
+            if (gridMaybeFunctions[target]) {
+                return this.convertMaybeFunction(value);
+            }
+            return value;
+        }, props);
     }
 
     onFilterChanged() {
@@ -490,10 +317,6 @@ export default class DashAgGrid extends Component {
                 JSON.stringify(prevProps.columnDefs) ||
             prevProps.columnSize !== columnSize
         ) {
-            this.props.setProps({
-                columnDefs: JSON.parse(JSON.stringify(this.props.columnDefs)),
-            });
-            this.setUpCols();
             this.updateColumnWidths();
         }
 
@@ -545,7 +368,7 @@ export default class DashAgGrid extends Component {
             // If it's collapsed, remove it from the list of open nodes
             openGroups.delete(e.node.key);
         }
-        this.setState({openGroups: openGroups});
+        this.setState({openGroups});
     }
 
     onSelectionChanged() {
@@ -668,65 +491,42 @@ export default class DashAgGrid extends Component {
         }
     }
 
-    evaluateFunction = (tempFunction, params) => {
-        const parsedCondition = esprima.parse(tempFunction).body[0].expression;
-        const value = evaluate(parsedCondition, {
-            params,
+    parseFunction(funcString) {
+        const parsedCondition = esprima.parse(funcString).body[0].expression;
+        const context = {
             d3,
             ...customFunctions,
             ...window.dashAgGridFunctions,
             ...window.dashSharedVariables,
-        });
-        return value;
-    };
+        };
+        return (params) => evaluate(parsedCondition, {params, ...context});
+    }
 
     /**
      * @params AG-Grid Styles rules attribute.
-     * See: https://www.ag-grid.com/react-grid/cell-styles/#cell-style-cell-class--cell-class-rules-params
+     * Cells: https://www.ag-grid.com/react-grid/cell-styles/#cell-style-cell-class--cell-class-rules-params
+     * Rows: https://www.ag-grid.com/react-grid/row-styles/#row-style-row-class--row-class-rules-params
      */
-    handleDynamicCellStyle({params, cellStyle = {}}) {
+    handleDynamicStyle(cellStyle) {
         const {styleConditions, defaultStyle} = cellStyle;
+        const _defaultStyle = defaultStyle || null;
 
-        if (styleConditions && styleConditions.length > 0) {
-            for (const styleCondition of styleConditions) {
-                const {condition, style} = styleCondition;
-
-                if (this.evaluateFunction(condition, params)) {
-                    return style;
+        if (styleConditions && styleConditions.length) {
+            const tests = styleConditions.map(({condition, style}) => ({
+                test: this.parseFunction(condition),
+                style,
+            }));
+            return (params) => {
+                for (const {test, style} of tests) {
+                    if (test(params)) {
+                        return style;
+                    }
                 }
-            }
+                return _defaultStyle;
+            };
         }
 
-        return defaultStyle ? defaultStyle : null;
-    }
-
-    /**
-     * @params AG-Grid Styles rules attribute.
-     * See: https://www.ag-grid.com/react-grid/row-styles/#row-style-row-class--row-class-rules-params
-     */
-    handleDynamicRowStyle({params, getRowStyle = {}}) {
-        const {styleConditions, defaultStyle} = getRowStyle;
-
-        if (styleConditions && styleConditions.length > 0) {
-            for (const styleCondition of styleConditions) {
-                const {condition, style} = styleCondition;
-
-                if (this.evaluateFunction(condition, params)) {
-                    return style;
-                }
-            }
-        }
-
-        return defaultStyle ? defaultStyle : null;
-    }
-
-    parseParamFunction(params, tempFunction) {
-        try {
-            return this.evaluateFunction(tempFunction, params);
-        } catch (err) {
-            console.log(err);
-        }
-        return '';
+        return _defaultStyle;
     }
 
     generateRenderer(Renderer) {
@@ -766,16 +566,11 @@ export default class DashAgGrid extends Component {
     }
 
     selectAll(opts) {
-        if (Object.keys(opts).includes('filtered')) {
-            if (opts.filtered) {
-                this.state.gridApi.selectAllFiltered();
-                this.props.setProps({
-                    selectAll: false,
-                });
-                return;
-            }
+        if (opts?.filtered) {
+            this.state.gridApi.selectAllFiltered();
+        } else {
+            this.state.gridApi.selectAll();
         }
-        this.state.gridApi.selectAll();
         this.props.setProps({
             selectAll: false,
         });
@@ -799,11 +594,7 @@ export default class DashAgGrid extends Component {
 
     buildArray(arr1, arr2) {
         if (arr1) {
-            if (
-                !JSON.parse(JSON.stringify(arr1)).includes(
-                    JSON.parse(JSON.stringify(arr2))
-                )
-            ) {
+            if (!arr1.includes(arr2)) {
                 return [...arr1, arr2];
             }
             return arr1;
@@ -815,9 +606,7 @@ export default class DashAgGrid extends Component {
         if (this.state.mounted) {
             if (this.state.gridApi) {
                 if (this.state.rowTransaction) {
-                    this.state.rowTransaction.map((data) =>
-                        this.applyRowTransaction(data)
-                    );
+                    this.state.rowTransaction.forEach(this.applyRowTransaction);
                     this.setState({rowTransaction: null});
                 }
                 this.applyRowTransaction(data);
@@ -840,17 +629,10 @@ export default class DashAgGrid extends Component {
     }
 
     autoSizeAllColumns(opts) {
-        const allColumnIds = [];
-        this.state.gridColumnApi.getColumnState().forEach((column) => {
-            allColumnIds.push(column.colId);
-        });
-        let skipHeaders = false;
-        if (Object.keys(opts).includes('skipHeaders')) {
-            if (opts.skipHeaders) {
-                skipHeaders = true;
-            }
-        }
-        this.state.gridColumnApi.autoSizeColumns(allColumnIds, skipHeaders);
+        const {getColumnState, autoSizeColumns} = this.state.gridColumnApi;
+        const allColumnIds = getColumnState().map((column) => column.colId);
+        const skipHeaders = Boolean(opts?.skipHeaders);
+        autoSizeColumns(allColumnIds, skipHeaders);
         this.props.setProps({
             autoSizeAllColumns: false,
         });
@@ -868,9 +650,7 @@ export default class DashAgGrid extends Component {
     render() {
         const {
             id,
-            getRowStyle,
             style,
-            theme,
             className,
             resetColumnState,
             exportDataAsCsv,
@@ -883,73 +663,16 @@ export default class DashAgGrid extends Component {
             csvExportParams,
             detailCellRendererParams,
             setProps,
+            // eslint-disable-next-line no-unused-vars
             dangerously_allow_code,
             dashGridOptions,
             ...restProps
         } = this.props;
 
-        const replaceFunc = (target) => {
-            const shouldWarn =
-                !dangerously_allow_code && expressWarn.includes(target);
-
-            const sanitize = (container) => {
-                const targetIn = container[target];
-                if (targetIn) {
-                    if (shouldWarn && typeof targetIn === 'string') {
-                        container[target] = () => '';
-                        console.error({
-                            prop: target,
-                            message:
-                                'you are trying to use an unsafe prop without dangerously_allow_code',
-                        });
-                    } else if (
-                        typeof targetIn === 'object' &&
-                        'function' in targetIn &&
-                        !replaceFunctions.includes(target)
-                    ) {
-                        const newFunc = JSON.parse(
-                            JSON.stringify(container[target].function)
-                        );
-                        container[target] = (params) =>
-                            this.parseParamFunction(params, newFunc);
-                    }
-                    if (replaceFunctions.includes(target)) {
-                        for (const [key, value] of Object.entries(
-                            container[target]
-                        )) {
-                            if (typeof value !== 'function') {
-                                container[target][key] = (params) =>
-                                    this.parseParamFunction(params, value);
-                            }
-                        }
-                    }
-                }
-            };
-
-            sanitize(this.props);
-            if (dashGridOptions) {
-                sanitize(dashGridOptions);
-            }
-        };
-
-        gridFunctions.map(replaceFunc);
-
-        let getRowId;
-        if (this.props.getRowId) {
-            getRowId = (params) =>
-                this.parseParamFunction(
-                    params,
-                    JSON.parse(JSON.stringify(this.props.getRowId))
-                );
-        }
-
-        this.setUpCols();
-
-        let newRowStyle;
-        if (getRowStyle) {
-            newRowStyle = (params) =>
-                this.handleDynamicRowStyle({params, getRowStyle});
-        }
+        const convertedProps = this.convertAllProps({
+            ...dashGridOptions,
+            ...restProps,
+        });
 
         if (resetColumnState) {
             this.resetColumnState();
@@ -1013,14 +736,12 @@ export default class DashAgGrid extends Component {
         return (
             <div
                 id={id}
-                className={theme ? 'ag-theme-' + theme : className}
+                className={className}
                 style={{
                     ...style,
                 }}
             >
                 <AgGridReact
-                    getRowId={getRowId}
-                    getRowStyle={newRowStyle}
                     onGridReady={this.onGridReady}
                     onSelectionChanged={this.onSelectionChanged}
                     onCellClicked={this.onCellClicked}
@@ -1037,8 +758,7 @@ export default class DashAgGrid extends Component {
                     )}
                     components={this.state.components}
                     detailCellRendererParams={newDetailCellRendererParams}
-                    {...dashGridOptions}
-                    {...omit(['theme', 'getRowId'], restProps)}
+                    {...convertedProps}
                 ></AgGridReact>
             </div>
         );

--- a/src/lib/utils/functionVars.js
+++ b/src/lib/utils/functionVars.js
@@ -1,171 +1,234 @@
 /**
- * Dangerous elements that can be used to execute strings as JS code:
+ * Dangerous elements inside column defs: If you pass a string,
+ * AG Grid will execute it as raw JS. We accept these strings if
+ * `dangerously_allow_code=true`, otherwise we require
+ * {function: <string>} and we'll eval & exec it safely.
  * https://www.ag-grid.com/react-data-grid/cell-expressions/#column-definition-expressions
  **/
-export const expressWarn = [
-    'valueGetter',
-    'valueFormatter',
-    'valueParser',
-    'valueSetter',
-    'filterValueGetter',
-    'headerValueGetter',
-    'template',
-];
+export const columnDangerousFunctions = {
+    valueGetter: 1,
+    valueFormatter: 1,
+    valueParser: 1,
+    valueSetter: 1,
+    filterValueGetter: 1,
+    headerValueGetter: 1,
+    template: 1,
+};
 
 /**
- * These props will always be replaced because the values inside the objects can only be strings to be evaluated
+ * Objects in either columns or top-level props with arbitrary keys
+ * whose values can only be function strings, which we will eval safely
  **/
-export const replaceFunctions = ['cellClassRules', 'rowClassRules'];
+export const objOfFunctions = {
+    cellClassRules: 1,
+    rowClassRules: 1,
+};
 
 /**
- * Functions from grid props https://www.ag-grid.com/react-data-grid/grid-options/
+ * Possible functions from top-level grid props
+ * Props in this list can be string constants (NOT eval'd by AG Grid) or functions,
+ * in which case we require {function: <string>} and we will eval them safely
+ * https://www.ag-grid.com/react-data-grid/grid-options/
  **/
-export const gridFunctions = [
+export const gridMaybeFunctions = {
     // Accessories
-    'getMainMenuItems',
-    'postProcessPopup',
+    getMainMenuItems: 1,
+    postProcessPopup: 1,
 
     // Clipboard
-    'processCellForClipboard',
-    'processHeaderForClipboard',
-    'processGroupHeaderForClipboard',
-    'processCellFromClipboard',
-    'sendToClipboard',
-    'processDataFromClipboard',
+    processCellForClipboard: 1,
+    processHeaderForClipboard: 1,
+    processGroupHeaderForClipboard: 1,
+    processCellFromClipboard: 1,
+    sendToClipboard: 1,
+    processDataFromClipboard: 1,
 
     // Filtering
-    'isExternalFilterPresent',
-    'doesExternalFilterPass',
+    isExternalFilterPresent: 1,
+    doesExternalFilterPass: 1,
 
     // Integrated Charts
-    'getChartToolbarItems',
-    'createChartContainer',
+    getChartToolbarItems: 1,
+    createChartContainer: 1,
 
     // Keyboard Navigation
-    'navigateToNextHeader',
-    'tabToNextHeader',
-    'navigateToNextCell',
-    'tabToNextCell',
+    navigateToNextHeader: 1,
+    tabToNextHeader: 1,
+    navigateToNextCell: 1,
+    tabToNextCell: 1,
 
     // Localisation
-    'getLocaleText',
+    getLocaleText: 1,
 
     // Miscellaneous
-    'getDocument',
+    getDocument: 1,
 
     // Pagination
-    'paginationNumberFormatter',
+    paginationNumberFormatter: 1,
 
     // Pivot and Aggregation
-    'processPivotResultColDef',
-    'processPivotResultColGroupDef',
-    'aggFuncs',
-    'getGroupRowAgg',
+    processPivotResultColDef: 1,
+    processPivotResultColGroupDef: 1,
+    aggFuncs: 1,
+    getGroupRowAgg: 1,
 
     // Rendering
-    'getBusinessKeyForNode',
-    'processRowPostCreate',
+    getBusinessKeyForNode: 1,
+    processRowPostCreate: 1,
 
     // Row Drag and Drop
-    'rowDragText',
+    rowDragText: 1,
 
     // Row Grouping
-    'isGroupOpenByDefault',
-    'initialGroupOrderComparator',
+    isGroupOpenByDefault: 1,
+    initialGroupOrderComparator: 1,
 
     // RowModel: Server-Side
-    'getChildCount',
-    'getServerSideGroupLevelParams',
-    'isServerSideGroupOpenByDefault',
-    'isApplyServerSideTransaction',
-    'isServerSideGroup',
-    'getServerSideGroupKey',
+    getChildCount: 1,
+    getServerSideGroupLevelParams: 1,
+    isServerSideGroupOpenByDefault: 1,
+    isApplyServerSideTransaction: 1,
+    isServerSideGroup: 1,
+    getServerSideGroupKey: 1,
 
     // Selection
-    'isRowSelectable',
-    'fillOperation',
+    isRowSelectable: 1,
+    fillOperation: 1,
 
     // Sorting
-    'postSortRows',
+    postSortRows: 1,
 
     // Styling
-    'getRowHeight',
-    'getRowStyle',
-    'getRowClass',
-    'rowClassRules',
-    'isFullWidthRow',
-];
+    getRowHeight: 1,
+    getRowStyle: 1,
+    getRowClass: 1,
+    // rowClassRules: 1, // keep replaceFunctions separate
+    isFullWidthRow: 1,
+};
 
 /**
- * Functions from columnDef props https://www.ag-grid.com/react-data-grid/column-properties/
+ * Functions from top-level grid props. Props in this list can ONLY be
+ * functions, so we accept a string and eval it safely
+ * https://www.ag-grid.com/react-data-grid/grid-options/
  **/
-export const columnFunctions = [
+export const gridOnlyFunctions = {
+    getRowId: 1,
+};
+
+/**
+ * Other top-level containers that look like a column def
+ */
+export const gridColumnContainers = {
+    defaultColDef: 1,
+    autoGroupColumnDef: 1,
+    defaultColGroupDef: 1,
+};
+
+/**
+ * Top-level containers that contain other functions or entire grids
+ */
+export const gridNestedFunctions = {
+    detailCellRendererParams: 1,
+    detailGridOptions: 1,
+};
+
+/**
+ * Possible functions from columnDef props
+ * Props in this list can be string constants (NOT eval'd by AG Grid) or functions,
+ * in which case we require {function: <string>} and we will eval them safely
+ * https://www.ag-grid.com/react-data-grid/column-properties/
+ **/
+export const columnMaybeFunctions = {
     // Columns
-    'keyCreator',
-    'equals',
-    'checkboxSelection',
-    'icons',
-    'suppressNavigable',
-    'suppressKeyboardEvent',
-    'filterParams',
+    keyCreator: 1,
+    equals: 1,
+    checkboxSelection: 1,
+    icons: 1,
+    suppressNavigable: 1,
+    suppressKeyboardEvent: 1,
+    // filterParams: 1, // nested, keep this separate
 
     // Columns: Editing
-    'editable',
-    'cellEditor',
-    'cellEditorSelector',
+    editable: 1,
+    cellEditor: 1,
+    cellEditorSelector: 1,
 
     // Columns: Events
-    'onCellDoubleClicked',
-    'onCellContextMenu',
+    onCellDoubleClicked: 1,
+    onCellContextMenu: 1,
 
     // Columns: Filter
-    'getQuickFilterText',
+    getQuickFilterText: 1,
 
     // Columns: Headers
-    'suppressHeaderKeyboardEvent',
-    'headerCheckboxSelection',
+    suppressHeaderKeyboardEvent: 1,
+    headerCheckboxSelection: 1,
 
     // Columns: Pivoting
-    'pivotComparator',
+    pivotComparator: 1,
 
     // Columns: Rendering and Styling
-    'cellStyle',
-    'cellClass',
-    'cellClassRules',
-    'tooltipComponent',
-    'cellRendererSelector',
+    cellStyle: 1,
+    cellClass: 1,
+    // cellClassRules: 1, // keep replaceFunctions separate
+    tooltipComponent: 1,
+    cellRendererSelector: 1,
 
     // Columns: Row Dragging
-    'rowDrag',
-    'rowDragText',
-    'dndSource',
-    'dndSourceOnRowDrag',
+    rowDrag: 1,
+    rowDragText: 1,
+    dndSource: 1,
+    dndSourceOnRowDrag: 1,
 
     // Columns: Row Grouping
-    'aggFunc',
-    'initialAggFunc',
+    aggFunc: 1,
+    initialAggFunc: 1,
 
     // Columns: Sort
-    'comparator',
+    comparator: 1,
 
     // Columns: Spanning
-    'colSpan',
-    'rowSpan',
+    colSpan: 1,
+    rowSpan: 1,
 
     // Columns: Tooltips
-    'tooltipValueGetter',
+    tooltipValueGetter: 1,
 
     // Groups
-    'toolPanelClass',
+    toolPanelClass: 1,
 
     // Groups: Header
-    'headerClass',
+    headerClass: 1,
 
     // Header Component Parameters
-    'showColumnMenu',
-    'progressSort',
-    'setSort',
+    showColumnMenu: 1,
+    progressSort: 1,
+    setSort: 1,
 
     // Header Group Component Parameters
-    'setExpanded',
-];
+    setExpanded: 1,
+
+    // In filterParams or filterParams.filterOptions[]
+    filterPlaceholder: 1,
+    predicate: 1,
+};
+
+/**
+ * Container objects inside columnDefs that may have other functions
+ * inside them, listed in other categories
+ **/
+export const columnNestedFunctions = {
+    cellRendererParams: 1,
+    headerComponentParams: 1,
+    headerGroupComponentParams: 1,
+    filterParams: 1,
+};
+
+/**
+ * Container arrays of objects inside columnDefs that may have functions
+ * inside them, listed in other categories
+ */
+export const columnArrayNestedFunctions = {
+    children: 1,
+    filterOptions: 1,
+};

--- a/tests/test_cell_clicked.py
+++ b/tests/test_cell_clicked.py
@@ -1,7 +1,6 @@
 import dash_ag_grid as dag
 from dash import Dash, html, dcc, Input, Output
 from . import utils
-import time
 from dash.testing.wait import until
 import json
 

--- a/tests/test_class_rules.py
+++ b/tests/test_class_rules.py
@@ -1,7 +1,6 @@
 import dash_ag_grid as dag
 from dash import Dash, html, dcc
 from . import utils
-import time
 from dash.testing.wait import until
 
 def test_cr001_class_rules(dash_duo):

--- a/tests/test_conditional_formatting.py
+++ b/tests/test_conditional_formatting.py
@@ -1,7 +1,6 @@
 import dash_ag_grid as dag
 from dash import Dash, html, dcc
 from . import utils
-import time
 from dash.testing.wait import until
 
 def test_cf001_conditional_formatting(dash_duo):

--- a/tests/test_custom_aggFunc_functions.py
+++ b/tests/test_custom_aggFunc_functions.py
@@ -4,10 +4,9 @@ Nested tables.
 
 import dash_ag_grid as dag
 import dash
-from dash import Input, Output, html, dcc
+from dash import html, dcc
 from . import utils
 from dash.testing.wait import until
-import time
 import requests
 
 def test_ca001_custom_aggFunc_functions(dash_duo):

--- a/tests/test_custom_components.py
+++ b/tests/test_custom_components.py
@@ -1,11 +1,10 @@
 import dash_ag_grid as dag
-from dash import Dash, html, Input, Output, State
+from dash import Dash, html, Input, Output
 import pandas as pd
 import yfinance as yf
 from . import utils
 import json
 import os
-import time
 
 def test_cc001_custom_components(dash_duo):
 

--- a/tests/test_custom_row_selectable.py
+++ b/tests/test_custom_row_selectable.py
@@ -1,11 +1,6 @@
 import dash_ag_grid as dag
-from dash import Dash, html, Input, Output
-import pandas as pd
-import yfinance as yf
+from dash import Dash, html
 from . import utils
-import json
-import os
-import time
 
 def test_cr001_custom_row_selectable(dash_duo):
     app = Dash(__name__)

--- a/tests/test_default_styles.py
+++ b/tests/test_default_styles.py
@@ -1,7 +1,6 @@
 import dash_ag_grid as dag
-from dash import Dash, html, dcc
+from dash import Dash, html
 from . import utils
-import time
 from dash.testing.wait import until
 
 def test_ds001_default_styles(dash_duo):

--- a/tests/test_markdown_components.py
+++ b/tests/test_markdown_components.py
@@ -3,7 +3,7 @@ Working with raw html in Markdown component
 """
 import dash_ag_grid as dag
 import dash
-from dash import Input, Output, html, dcc
+from dash import html, dcc
 from . import utils
 from dash.testing.wait import until
 

--- a/tests/test_recursive_functions.py
+++ b/tests/test_recursive_functions.py
@@ -3,11 +3,8 @@ Nested tables.
 """
 
 import dash_ag_grid as dag
-import dash
-from dash import Input, Output, html, dcc, Dash
+from dash import html, Dash
 from . import utils
-from dash.testing.wait import until
-import time
 
 def test_rf001_recursive_functions(dash_duo):
     app = Dash(__name__)

--- a/tests/test_row_data_sync.py
+++ b/tests/test_row_data_sync.py
@@ -2,8 +2,6 @@ import dash_ag_grid as dag
 from dash import Dash, html, dcc, Input, Output, no_update, ctx
 import json
 from . import utils
-import time
-from dash.testing.wait import until
 
 def test_rs001_rowdata_sync(dash_duo):
     app = Dash(__name__)

--- a/tests/test_row_menu.py
+++ b/tests/test_row_menu.py
@@ -1,5 +1,5 @@
 import dash_ag_grid as dag
-from dash import Dash, html, Input, Output, State
+from dash import Dash, html, Input, Output
 from . import utils
 
 def test_rm001_row_menu(dash_duo):

--- a/tests/test_selected_rows.py
+++ b/tests/test_selected_rows.py
@@ -2,7 +2,6 @@ import dash_ag_grid as dag
 from dash import Dash, html, dcc, Output, Input, no_update
 import requests
 from . import utils
-import time
 
 def test_sr001_selected_rows(dash_duo):
 

--- a/tests/test_selection_buttons.py
+++ b/tests/test_selection_buttons.py
@@ -2,7 +2,6 @@ import dash_ag_grid as dag
 from dash import Dash, html, dcc, Output, Input, no_update, ctx
 import requests
 from . import utils
-import time
 
 def test_sb001_selection_buttons(dash_duo):
     app = Dash(__name__)


### PR DESCRIPTION
Change from in-place cleaning of function props to building new prop objects with function strings converted to functions.

@BSd3v please take a look - a few tests are failing and I haven't looked at why yet, and I'm still not 100% sure I understand all the props (which may be why some tests are failing) but I think you'll get the point of the refactoring I'm trying to do, so that the props provided by the user are kept unchanged even while the props seen by AG Grid are converted and sanitized.

I did a few things to improve performance as well: splitting out `esprima.parse` from the execution of the function, which only needs `evaluate`; turning the `functionVars` categories into maps instead of arrays so we can do a hash lookup instead of `Array.includes`...