### PR TITLE
floating-columnState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to `dash-ag-grid` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source Dash AG Grid repo
 
+## [unreleased]
+
+### Removed
+
+### Added
+
+### Updated
+- [#174](https://github.com/plotly/dash-ag-grid/pull/174)
+  - `columnState` floats during grid interaction and only gets pushed when sent in a callback
+  - `columnDefs` trumps `columnState` if it is pushed in a callback without a `columnState`
+
+### Fixed
+- [#174](https://github.com/plotly/dash-ag-grid/pull/174)
+  - `Markdown` renderer now will pass back `''` instead of `undefined` if there isnt a value
+
 ## [2.0.0] - 2023-05-02
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 
 ### Fixed
 - [#174](https://github.com/plotly/dash-ag-grid/pull/174)
-  - `Markdown` renderer now will pass back `''` instead of `undefined` if there isnt a value
+  - `Markdown` renderer now displays a blank cell rather than writing `undefined` if there is no value. Fixes [#171](https://github.com/plotly/dash-ag-grid/issues/171)
 
 ## [2.0.0] - 2023-05-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
                 "style-loader": "^3.3.2",
                 "styled-jsx": "^5.1.2",
                 "webpack": "^5.81.0",
-                "webpack-cli": "^5.0.2"
+                "webpack-cli": "^5.0.2",
+                "rimraf":  "^3.0.2"
             },
             "engines": {
                 "node": ">=8.11.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/plotly/dash-ag-grid",
     "main": "dash_ag_grid/dash_ag_grid.min.js",
     "scripts": {
-        "prepublishOnly": "rm -rf lib && babel src --out-dir lib --copy-files --config-file ./.babelrc && rm -rf lib/jl/ lib/*.jl",
+        "prepublishOnly": "rimraf -rf lib && babel src --out-dir lib --copy-files --config-file ./.babelrc && rimraf -rf lib/jl/ lib/*.jl",
         "build:js": "webpack --mode production",
         "build:backends": "dash-generate-components ./src/lib/components dash_ag_grid -p package-info.json --r-prefix '' --jl-prefix ''",
         "build": "run-s prepublishOnly build:js build:backends",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         "style-loader": "^3.3.2",
         "styled-jsx": "^5.1.2",
         "webpack": "^5.81.0",
-        "webpack-cli": "^5.0.2"
+        "webpack-cli": "^5.0.2",
+        "rimraf": "^3.0.2"
     },
     "files": [
         "/dash_ag_grid/*{.js,.map}",

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -538,7 +538,7 @@ export default class DashAgGrid extends Component {
         }
         if (gridApi) {
             if (columnState) {
-                if (!equals(columnState, this.props.columnState)) {
+                if (columnState !== this.props.columnState) {
                     return true;
                 }
             }
@@ -576,9 +576,9 @@ export default class DashAgGrid extends Component {
             paginationGoTo,
         } = this.props;
 
-        if (this.state.gridColumnApi) {
+        if (this.state.gridColumnApi && this.props.loading_state.is_loading) {
             if (
-                !equals(this.props.columnState, this.uiColumnState) &&
+                this.props.columnState !== this.uiColumnState &&
                 !this.state.columnState_push
             ) {
                 this.setState({columnState_push: true});

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -157,8 +157,6 @@ export default class DashAgGrid extends Component {
 
         this.convertedPropCache = {};
 
-        this.uiColumnState = null;
-
         this.state = {
             ...this.props.parentState,
             components: {
@@ -578,7 +576,7 @@ export default class DashAgGrid extends Component {
 
         if (this.state.gridColumnApi && this.props.loading_state.is_loading) {
             if (
-                this.props.columnState !== this.uiColumnState &&
+                this.props.columnState !== prevProps.columnState &&
                 !this.state.columnState_push
             ) {
                 this.setState({columnState_push: true});
@@ -972,7 +970,7 @@ export default class DashAgGrid extends Component {
         if (!this.state.gridApi || this.props.updateColumnState) {
             return;
         }
-        this.uiColumnState = this.props.columnState;
+
         if (this.state.columnState_push) {
             this.state.gridColumnApi.applyColumnState({
                 state: this.props.columnState,
@@ -1087,8 +1085,6 @@ export default class DashAgGrid extends Component {
         var columnState = JSON.parse(
             JSON.stringify(this.state.gridColumnApi.getColumnState())
         );
-
-        this.uiColumnState = columnState;
 
         this.props.setProps({
             columnState,

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -515,7 +515,7 @@ export default class DashAgGrid extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        const {gridColumnApi, gridApi} = this.state;
+        const {gridApi} = this.state;
         const {columnState, filterModel, selectedRows} = nextProps;
 
         if (
@@ -536,14 +536,7 @@ export default class DashAgGrid extends Component {
         }
         if (gridApi) {
             if (columnState) {
-                if (
-                    !equals(
-                        columnState,
-                        JSON.parse(
-                            JSON.stringify(gridColumnApi.getColumnState())
-                        )
-                    )
-                ) {
+                if (!equals(columnState, this.props.columnState)) {
                     return true;
                 }
             }

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -157,6 +157,8 @@ export default class DashAgGrid extends Component {
 
         this.convertedPropCache = {};
 
+        this.uiColumnState = null;
+
         this.state = {
             ...this.props.parentState,
             components: {
@@ -574,9 +576,9 @@ export default class DashAgGrid extends Component {
             paginationGoTo,
         } = this.props;
 
-        if (this.state.gridColumnApi && this.props.loading_state.is_loading) {
+        if (this.state.gridColumnApi) {
             if (
-                this.props.columnState !== prevProps.columnState &&
+                !equals(this.props.columnState, this.uiColumnState) &&
                 !this.state.columnState_push
             ) {
                 this.setState({columnState_push: true});
@@ -970,6 +972,7 @@ export default class DashAgGrid extends Component {
         if (!this.state.gridApi || this.props.updateColumnState) {
             return;
         }
+        this.uiColumnState = this.props.columnState;
         if (this.state.columnState_push) {
             this.state.gridColumnApi.applyColumnState({
                 state: this.props.columnState,
@@ -1081,10 +1084,14 @@ export default class DashAgGrid extends Component {
             return;
         }
 
+        var columnState = JSON.parse(
+            JSON.stringify(this.state.gridColumnApi.getColumnState())
+        );
+
+        this.uiColumnState = columnState;
+
         this.props.setProps({
-            columnState: JSON.parse(
-                JSON.stringify(this.state.gridColumnApi.getColumnState())
-            ),
+            columnState,
             updateColumnState: false,
         });
     }

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -169,6 +169,7 @@ export default class DashAgGrid extends Component {
             openGroups: {},
             gridApi: null,
             gridColumnApi: null,
+            columnState_push: true,
         };
 
         this.selectionEventFired = false;
@@ -580,6 +581,15 @@ export default class DashAgGrid extends Component {
             paginationGoTo,
         } = this.props;
 
+        if (this.state.gridColumnApi && this.props.loading_state.is_loading) {
+            if (
+                this.props.columnState !== prevProps.columnState &&
+                !this.state.columnState_push
+            ) {
+                this.setState({columnState_push: true});
+            }
+        }
+
         if (id !== prevProps.id) {
             if (id) {
                 agGridRefs[id] = this.reference.current;
@@ -660,7 +670,11 @@ export default class DashAgGrid extends Component {
             }
             // Hydrate virtualRowData
             this.onFilterChanged(true);
-            this.setState({mounted: true, openGroups: groups});
+            this.setState({
+                mounted: true,
+                openGroups: groups,
+                columnState_push: false,
+            });
             this.updateColumnState();
         }
 
@@ -963,10 +977,13 @@ export default class DashAgGrid extends Component {
         if (!this.state.gridApi || this.props.updateColumnState) {
             return;
         }
-        this.state.gridColumnApi.applyColumnState({
-            state: this.props.columnState,
-            applyOrder: true,
-        });
+        if (this.state.columnState_push) {
+            this.state.gridColumnApi.applyColumnState({
+                state: this.props.columnState,
+                applyOrder: true,
+            });
+            this.setState({columnState_push: false});
+        }
     }
 
     // Event actions that reset

--- a/src/lib/renderers/markdownRenderer.js
+++ b/src/lib/renderers/markdownRenderer.js
@@ -34,7 +34,7 @@ export default function MarkdownRenderer(props) {
             }}
             className="agGrid-Markdown"
             rehypePlugins={rehypePlugins}
-            children={String(value)}
+            children={value ? String(value) : null}
         />
     );
 }

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -317,4 +317,9 @@ export const OMIT_PROP_RENDER = [
 /**
  * States to not trigger a render update
  */
-export const OMIT_STATE_RENDER = ['gridColumnApi', 'mounted', 'openGroups'];
+export const OMIT_STATE_RENDER = [
+    'gridColumnApi',
+    'mounted',
+    'openGroups',
+    'columnState_push',
+];

--- a/tests/test_column_state.py
+++ b/tests/test_column_state.py
@@ -2,10 +2,10 @@ from dash import Dash, html, Output, Input, no_update, State, ctx
 import dash_ag_grid as dag
 import plotly.express as px
 import json
+import time
 
 from . import utils
 from dash.testing.wait import until
-from selenium.webdriver.common.action_chains import ActionChains
 
 
 df = px.data.election()
@@ -233,11 +233,8 @@ def test_cs001_column_state(dash_duo):
     dash_duo.find_element('#load-column-state-button').click()
     until(lambda: json.dumps(colState) in dash_duo.find_element('#reset-column-state-grid-pre').text, timeout=3)
 
-    (
-        ActionChains(dash_duo.driver)
-            .move_to_element(dash_duo.find_element('#load-column-defs'))
-            .click()
-    ).perform()
+    time.sleep(.2) ### pause to emulate user clicking, if no pause column state doesnt trigger properly
+    dash_duo.find_element('#load-column-defs').click()
     until(lambda: json.dumps(alt_colState) in dash_duo.find_element('#reset-column-state-grid-pre').text, timeout=3)
     grid.wait_for_cell_text(0, 0, "32000")
 

--- a/tests/test_markdown_components.py
+++ b/tests/test_markdown_components.py
@@ -71,27 +71,7 @@ def test_mc001_markdown_components(dash_duo):
         },
     ]
 
-    rowData2 = [
-        {
-            "make": "*Toyota* in italics",
-            "model": "`code snippet`",
-            "image": "{0} {0} {0} {0} {0}".format(
-                "![alt text: rain](https://www.ag-grid.com/example-assets/weather/rain.png)"
-            ),
-        },
-        {
-            "make": "**Ford** in bold",
-            "model": "Mondeo",
-            "image": "{0} {0} {0} {0}".format(
-                "![alt text: sun](https://www.ag-grid.com/example-assets/weather/sun.png)"
-            ),
-        },
-        {
-            "make": "***Porsche*** in both",
-            "model": "<b>Boxster</b> in HTML bold",
-            "image": "![alt text: rain](https://www.ag-grid.com/example-assets/weather/rain.png)",
-        },
-    ]
+    rowData2 = [{k:row[k] for k in row if k != "link"} for row in rowData]
 
     raw_html_example1 = html.Div(
         [

--- a/tests/test_markdown_components.py
+++ b/tests/test_markdown_components.py
@@ -71,6 +71,28 @@ def test_mc001_markdown_components(dash_duo):
         },
     ]
 
+    rowData2 = [
+        {
+            "make": "*Toyota* in italics",
+            "model": "`code snippet`",
+            "image": "{0} {0} {0} {0} {0}".format(
+                "![alt text: rain](https://www.ag-grid.com/example-assets/weather/rain.png)"
+            ),
+        },
+        {
+            "make": "**Ford** in bold",
+            "model": "Mondeo",
+            "image": "{0} {0} {0} {0}".format(
+                "![alt text: sun](https://www.ag-grid.com/example-assets/weather/sun.png)"
+            ),
+        },
+        {
+            "make": "***Porsche*** in both",
+            "model": "<b>Boxster</b> in HTML bold",
+            "image": "![alt text: rain](https://www.ag-grid.com/example-assets/weather/rain.png)",
+        },
+    ]
+
     raw_html_example1 = html.Div(
         [
             dcc.Markdown(
@@ -102,9 +124,24 @@ def test_mc001_markdown_components(dash_duo):
         ]
     )
 
+    raw_html_example3 = html.Div(
+        [
+            dcc.Markdown(
+                "This grid has both Markdown and raw HTML. By default, raw HTML is not rendered."
+            ),
+            dag.AgGrid(
+                id="not_dangerous2",
+                columnSize="sizeToFit",
+                columnDefs=columnDefs,
+                rowData=rowData2,
+            ),
+            html.Hr(),
+        ]
+    )
+
 
     app.layout = html.Div(
-        [raw_html_example1, raw_html_example2],
+        [raw_html_example1, raw_html_example2, raw_html_example3],
         style={"flexWrap": "wrap"},
     )
 
@@ -112,6 +149,7 @@ def test_mc001_markdown_components(dash_duo):
 
     safe_grid = utils.Grid(dash_duo, "not_dangerous")
     dangerous_grid = utils.Grid(dash_duo, "dangerous")
+    safe2_grid = utils.Grid(dash_duo, "not_dangerous2")
 
     for grid in [safe_grid, dangerous_grid]:
         grid.wait_for_cell_text(0, 0, "Toyota in italics")
@@ -132,3 +170,7 @@ def test_mc001_markdown_components(dash_duo):
     assert dangerous_grid.get_cell(2, 2).get_attribute('innerHTML') == '<div class="agGrid-Markdown"><div><a href="#">Example</a></div></div>'
     dangerous_grid.wait_for_cell_text(1, 2, 'Link to new tab')
     assert dangerous_grid.get_cell(1, 2).get_attribute('innerHTML') == '<div class="agGrid-Markdown"><div><a href="#" target="_blank">Link to new tab</a></div></div>'
+
+    assert safe2_grid.get_cell(0, 2).text == ''
+    assert safe2_grid.get_cell(1, 2).text == ''
+    assert safe2_grid.get_cell(2, 2).text == ''

--- a/tests/test_row_groupings.py
+++ b/tests/test_row_groupings.py
@@ -1,0 +1,65 @@
+import dash_ag_grid as dag
+from dash import Dash, html, dcc, Input, Output
+from . import utils
+from dash.testing.wait import until
+import pandas as pd
+import json
+
+def test_rg001_row_groupings(dash_duo):
+    app = Dash(__name__)
+
+    df = pd.read_csv(
+        "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
+    )
+
+    columnDefs = [
+        {"field": "country", "enableRowGroup": True, "rowGroup": True, "hide": True},
+        {"field": "year", "enableRowGroup": True, "rowGroup": True, "hide": True},
+        {"field": "sport", "enableRowGroup": True},
+        {"field": "gold"},
+        {"field": "silver"},
+        {"field": "bronze"},
+    ]
+
+    app.layout = html.Div(
+        [
+            dag.AgGrid(
+                columnDefs=columnDefs,
+                rowData=df.to_dict("records")[:20],
+                columnSize="sizeToFit",
+                defaultColDef={"resizable": True, "sortable": True, "filter": True},
+                enableEnterpriseModules=True,
+                dashGridOptions={"rowGroupPanelShow": "always"},
+                id="grid"
+            ),
+            html.Div(id='columnState')
+        ],
+        style={"margin": 20},
+    )
+
+    @app.callback(
+        Output('columnState', 'children'),
+        Input('grid', 'columnState')
+    )
+    def columnState(s):
+        return json.dumps(s)
+
+    dash_duo.start_server(app)
+
+    grid = utils.Grid(dash_duo, "grid")
+
+    until(lambda: 'United States' in grid.get_cell(0, 0).text, timeout=3)
+
+    ## grouped columns are hidden
+    grid.add_column_drop(3)
+
+    until(lambda: 'Country' in dash_duo.find_element('.ag-column-drop').text, timeout=3)
+    until(lambda: 'Year' in dash_duo.find_element('.ag-column-drop').text, timeout=3)
+    until(lambda: 'Sport' in dash_duo.find_element('.ag-column-drop').text, timeout=3)
+    assert ['Country', 'Year', 'Sport'] == dash_duo.find_element('.ag-column-drop').text.split('\n')
+
+    grid.drag_column_list(2, 0)
+    assert ['Sport', 'Country', 'Year'] == dash_duo.find_element('.ag-column-drop').text.split('\n')
+    until(lambda: 'Swimming' in grid.get_cell(0, 0).text, timeout=3)
+    grid.get_cell_expandable(0, 0).click()
+    until(lambda: 'United States' in grid.get_cell(1, 0).text, timeout=3)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,37 @@ class Grid:
             .release()
         ).perform()
 
+    def drag_column_list(self, from_index, to_index):
+        from_col = self.dash_duo.find_element(f'#{self.id} .ag-column-drop-cell[aria-posinset="{from_index+1}"]'
+                                              f' .ag-icon-grip')
+        to_col = self.dash_duo.find_element(f'#{self.id} .ag-column-drop-cell[aria-posinset="{to_index+1}"]')
+        (
+            ActionChains(self.dash_duo.driver)
+                .move_to_element(from_col)
+                .click_and_hold()
+                .move_to_location(
+                to_col.location["x"] + to_col.size["width"] * 0.5,
+                to_col.location["y"] + to_col.size["height"] * 0.5
+            )
+                .pause(0.5)
+                .release()
+        ).perform()
+
+    def add_column_drop(self, from_index):
+        from_col = self.get_header_cell(from_index)
+        list = self.dash_duo.find_element(f'#{self.id} .ag-column-drop-wrapper .ag-column-drop .ag-column-drop-list')
+        (
+            ActionChains(self.dash_duo.driver)
+                .move_to_element(from_col)
+                .click_and_hold()
+                .move_to_location(
+                    list.location["x"] + list.size["width"] * 1.2,
+                    list.location["y"] + list.size["height"] * 0.5
+                )
+                .pause(0.5)
+                .release()
+        ).perform()
+
     def pin_col(self, col, pinned_cols=0):
         from_col = self.get_header_cell(col)
         pin_col = self.get_header_cell(pinned_cols)


### PR DESCRIPTION
`columnState` floats during grid interaction and only gets pushed when sent in a callback
`columnDefs` trumps `columnState` if it is pushed in a callback without a `columnState`
`Markdown` renderer now will pass back '' instead of `undefined` if there isnt a value