### PR TITLE
fixing `columnState` for use with React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 ### Added
 - [#199](https://github.com/plotly/dash-ag-grid/pull/199) Add `scrollTo` prop which allows scrolling to rows and columns.
 - [#209](https://github.com/plotly/dash-ag-grid/pull/209)
-  - Adding `getApi` and `getColumnApi` to `dash_ag_grid` namespace to allow for JS functions to call the grid's API directly
+  - Added `getApi` and `getColumnApi` to `dash_ag_grid` namespace to allow for JS functions to call the grid's API directly
+
+### Fixed
+- [210](https://github.com/plotly/dash-ag-grid/pull/210)
+  - fixed issue where `columnState` wasnt being applied with React 18
+
+### Updated
+- [210](https://github.com/plotly/dash-ag-grid/pull/210)
+  - migrated props that use `setProps` from the `render()` to `componentDidUpdate`
 
 ## [2.1.0] - 2023-06-02
 

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -582,11 +582,14 @@ export default class DashAgGrid extends Component {
             deleteSelectedRows,
             filterModel,
             columnState,
+            columnSize,
             paginationGoTo,
             scrollTo,
+            rowTransaction,
+            updateColumnState,
         } = this.props;
 
-        if (this.state.gridColumnApi && this.props.loading_state.is_loading) {
+        if (this.state.gridApi && prevProps.loading_state.is_loading) {
             if (
                 this.props.columnState !== prevProps.columnState &&
                 !this.state.columnState_push
@@ -708,6 +711,57 @@ export default class DashAgGrid extends Component {
             !this.selectionEventFired
         ) {
             this.setSelection(selectedRows);
+        }
+
+        if (this.state.gridApi && this.state.gridApi === prevState.gridApi) {
+            if (filterModel) {
+                if (this.state.gridApi) {
+                    if (this.state.gridApi.getFilterModel() !== filterModel) {
+                        this.state.gridApi.setFilterModel(filterModel);
+                    }
+                }
+            }
+
+            if (paginationGoTo || paginationGoTo === 0) {
+                this.paginationGoTo();
+            }
+
+            if (scrollTo) {
+                this.scrollTo();
+            }
+
+            if (columnSize) {
+                this.updateColumnWidths();
+            }
+
+            if (resetColumnState) {
+                this.resetColumnState();
+            }
+
+            if (exportDataAsCsv) {
+                this.exportDataAsCsv(csvExportParams);
+            }
+
+            if (selectAll) {
+                this.selectAll(selectAll);
+            }
+
+            if (deselectAll) {
+                this.deselectAll();
+            }
+
+            if (deleteSelectedRows) {
+                this.deleteSelectedRows();
+            }
+
+            if (rowTransaction) {
+                this.rowTransaction(rowTransaction);
+            }
+            if (updateColumnState) {
+                this.updateColumnState();
+            } else if (this.state.columnState_push) {
+                this.setColumnState();
+            }
         }
 
         // Reset selection event flag
@@ -1210,76 +1264,14 @@ export default class DashAgGrid extends Component {
     }
 
     render() {
-        const {
-            id,
-            style,
-            className,
-            resetColumnState,
-            exportDataAsCsv,
-            selectAll,
-            deselectAll,
-            deleteSelectedRows,
-            rowTransaction,
-            updateColumnState,
-            csvExportParams,
-            dashGridOptions,
-            filterModel,
-            columnState,
-            paginationGoTo,
-            columnSize,
-            scrollTo,
-            ...restProps
-        } = this.props;
+        const {id, style, className, dashGridOptions, ...restProps} =
+            this.props;
 
         const passingProps = pick(PASSTHRU_PROPS, restProps);
 
         const convertedProps = this.convertAllProps(
             omit(NO_CONVERT_PROPS, {...dashGridOptions, ...restProps})
         );
-
-        if (filterModel) {
-            if (this.state.gridApi) {
-                if (this.state.gridApi.getFilterModel() !== filterModel) {
-                    this.state.gridApi.setFilterModel(filterModel);
-                }
-            }
-        }
-
-        if (paginationGoTo || paginationGoTo === 0) {
-            this.paginationGoTo();
-        }
-
-        if (scrollTo) {
-            this.scrollTo();
-        }
-
-        if (columnSize) {
-            this.updateColumnWidths();
-        }
-
-        if (resetColumnState) {
-            this.resetColumnState();
-        }
-
-        if (exportDataAsCsv) {
-            this.exportDataAsCsv(csvExportParams);
-        }
-
-        if (selectAll) {
-            this.selectAll(selectAll);
-        }
-
-        if (deselectAll) {
-            this.deselectAll();
-        }
-
-        if (deleteSelectedRows) {
-            this.deleteSelectedRows();
-        }
-
-        if (rowTransaction) {
-            this.rowTransaction(rowTransaction);
-        }
 
         let alignedGrids;
         if (dashGridOptions) {
@@ -1304,12 +1296,6 @@ export default class DashAgGrid extends Component {
                     addGrid(dashGridOptions.alignedGrids);
                 }
             }
-        }
-
-        if (updateColumnState) {
-            this.updateColumnState();
-        } else if (columnState && !this.props.loading_state.is_loading) {
-            this.setColumnState();
         }
 
         return (

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -296,6 +296,19 @@ export const PROPS_NOT_FOR_AG_GRID = [
     'getDetailResponse',
     'dangerously_allow_code',
     'alignedGrids',
+    'resetColumnState',
+    'exportDataAsCsv',
+    'selectAll',
+    'deselectAll',
+    'deleteSelectedRows',
+    'rowTransaction',
+    'updateColumnState',
+    'csvExportParams',
+    'filterModel',
+    'columnState',
+    'paginationGoTo',
+    'columnSize',
+    'scrollTo',
 ];
 
 /**
@@ -317,9 +330,4 @@ export const OMIT_PROP_RENDER = [
 /**
  * States to not trigger a render update
  */
-export const OMIT_STATE_RENDER = [
-    'gridColumnApi',
-    'mounted',
-    'openGroups',
-    'columnState_push',
-];
+export const OMIT_STATE_RENDER = ['gridColumnApi', 'mounted', 'openGroups'];

--- a/tests/test_column_state.py
+++ b/tests/test_column_state.py
@@ -257,4 +257,4 @@ def test_cs001_column_state(dash_duo):
         in dash_duo.find_element("#reset-column-state-grid-pre").text,
         timeout=3,
     )
-    # grid.wait_for_all_header_texts(["Make", "Price", "Model"])
+    grid.wait_for_all_header_texts(["Make", "Price", "Model"])


### PR DESCRIPTION
* migrated props that use `setProps` from `render()` to `componentDidUpdate` (this fixed the `bad setState()` error)
* adjusted `columnState` if statement to use `prevProps.loading_state`