### PR TITLE
Propagate muti-cell paste event to Dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `dash-ag-grid` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source Dash AG Grid repo
 
+## UNRELEASED
+
+### Fixed 
+- [#262](https://github.com/plotly/dash-ag-grid/issues/262) Fixed all-but-one `cellValueChanged` events suppressed for multi-cell edits
+
 ## [2.4.0] - 2023-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 
 ## UNRELEASED
 
-### Fixed 
-- [#262](https://github.com/plotly/dash-ag-grid/issues/262) Fixed all-but-one `cellValueChanged` events suppressed for multi-cell edits
+### Changed 
+
+- The `cellValueChanged` property has changed been changed from a (single) event object to a _list_ of event objects. For multi-cell edits, the list will contain an element per change. In other cases, the list will contain a single element. Fixes [#262](https://github.com/plotly/dash-ag-grid/issues/262) 
 
 ## [2.4.0] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 
 ### Changed 
 
-- The `cellValueChanged` property has changed been changed from a (single) event object to a _list_ of event objects. For multi-cell edits, the list will contain an element per change. In other cases, the list will contain a single element. Fixes [#262](https://github.com/plotly/dash-ag-grid/issues/262) 
+- [#261](https://github.com/plotly/dash-ag-grid/pull/261) The `cellValueChanged` property has changed been changed from a (single) event object to a _list_ of event objects. For multi-cell edits, the list will contain an element per change. In other cases, the list will contain a single element. Fixes [#262](https://github.com/plotly/dash-ag-grid/issues/262) 
 
 ## [2.4.0] - 2023-10-17
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "build:js": "webpack --mode production",
         "build:backends": "dash-generate-components ./src/lib/components dash_ag_grid -p package-info.json --r-prefix '' --jl-prefix ''",
         "build": "run-s prepublishOnly build:js build:backends",
-        "postbuild": "es-check es2015 dash_ag_grid/*.js",
+        "postbuild": "es-check es2017 dash_ag_grid/*.js",
         "private::format.eslint": "eslint --quiet --fix src",
         "private::format.prettier": "prettier --write src --ignore-path=.prettierignore",
         "format": "run-s private::format.*",

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -682,42 +682,44 @@ DashAgGrid.propTypes = {
     /**
      * Value has changed after editing.
      */
-    cellValueChanged: PropTypes.arrayOf(PropTypes.shape({
-        /**
-         * rowIndex, typically a row number
-         */
-        rowIndex: PropTypes.number,
+    cellValueChanged: PropTypes.arrayOf(
+        PropTypes.shape({
+            /**
+             * rowIndex, typically a row number
+             */
+            rowIndex: PropTypes.number,
 
-        /**
-         * Row Id from the grid, this could be a number automatically, or set via getRowId
-         */
-        rowId: PropTypes.any,
+            /**
+             * Row Id from the grid, this could be a number automatically, or set via getRowId
+             */
+            rowId: PropTypes.any,
 
-        /**
-         * data, data object from the row
-         */
-        data: PropTypes.object,
+            /**
+             * data, data object from the row
+             */
+            data: PropTypes.object,
 
-        /**
-         * old value of the cell
-         */
-        oldValue: PropTypes.any,
+            /**
+             * old value of the cell
+             */
+            oldValue: PropTypes.any,
 
-        /**
-         * new value of the cell
-         */
-        newValue: PropTypes.any,
+            /**
+             * new value of the cell
+             */
+            newValue: PropTypes.any,
 
-        /**
-         * column where the cell was changed
-         */
-        colId: PropTypes.any,
+            /**
+             * column where the cell was changed
+             */
+            colId: PropTypes.any,
 
-        /**
-         * Timestamp of when the event was fired
-         */
-        timestamp: PropTypes.any,
-    })),
+            /**
+             * Timestamp of when the event was fired
+             */
+            timestamp: PropTypes.any,
+        })
+    ),
 
     /**
      * Other ag-grid options

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -682,7 +682,7 @@ DashAgGrid.propTypes = {
     /**
      * Value has changed after editing.
      */
-    cellValueChanged: PropTypes.shape({
+    cellValueChanged: PropTypes.arrayOf(PropTypes.shape({
         /**
          * rowIndex, typically a row number
          */
@@ -717,7 +717,7 @@ DashAgGrid.propTypes = {
          * Timestamp of when the event was fired
          */
         timestamp: PropTypes.any,
-    }),
+    })),
 
     /**
      * Other ag-grid options

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -925,22 +925,22 @@ export default class DashAgGrid extends Component {
             value,
             colId,
             timestamp,
-        }
+        };
         // Append it to current change session.
         let pendingChanges = this.state.cellValueChanged;
-        if(pendingChanges === undefined){
-            pendingChanges = [newChange]
+        if(typeof pendingChanges === 'undefined' || pendingChanges === null){
+            pendingChanges = [newChange];
         }
         else{
-            pendingChanges.push(newChange)
+            pendingChanges.push(newChange);
         }
-        this.setState({cellValueChanged: pendingChanges})
+        this.setState({cellValueChanged: pendingChanges});
     }
 
     afterCellValueChanged() {
-        const cellValueChanged = this.state.cellValueChanged;
+        const {cellValueChanged} = this.state;
         // Guard against multiple invocations of the same change session.
-        if(cellValueChanged === undefined){
+        if(typeof cellValueChanged === 'undefined' || cellValueChanged === null){
             return;
         }
         // Send update(s) for current change session to Dash.
@@ -951,7 +951,7 @@ export default class DashAgGrid extends Component {
         });
         this.syncRowData();
         // Mark current change session as ended.
-        this.setState({cellValueChanged: undefined})
+        this.setState({cellValueChanged: null});
     }
 
     onDisplayedColumnsChanged() {
@@ -1353,7 +1353,7 @@ export default class DashAgGrid extends Component {
                     onCellDoubleClicked={this.onCellDoubleClicked}
                     onCellValueChanged={debounce(
                         this.afterCellValueChanged,
-                        CELL_VALUE_CHANGED_DEBOUNCE_MS, // FIXME: SET VARIABLE(!)
+                        CELL_VALUE_CHANGED_DEBOUNCE_MS,
                         this.onCellValueChanged,
                     )}
                     onFilterChanged={this.onFilterChanged}

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -185,6 +185,7 @@ export default class DashAgGrid extends Component {
 
         this.selectionEventFired = false;
         this.reference = React.createRef();
+        this.pendingChanges = null;
     }
 
     onPaginationChanged() {
@@ -927,13 +928,12 @@ export default class DashAgGrid extends Component {
             timestamp,
         };
         // Append it to current change session.
-        let pendingChanges = this.state.cellValueChanged;
-        if (typeof pendingChanges === 'undefined' || pendingChanges === null) {
-            pendingChanges = [newChange];
+        if (typeof this.pendingChanges === 'undefined' || this.pendingChanges === null) {
+            this.pendingChanges = [newChange];
         } else {
-            pendingChanges.push(newChange);
+            this.pendingChanges.push(newChange);
         }
-        this.setState({cellValueChanged: pendingChanges});
+        this.setState({cellValueChanged: this.pendingChanges});
     }
 
     afterCellValueChanged() {
@@ -954,6 +954,7 @@ export default class DashAgGrid extends Component {
         this.syncRowData();
         // Mark current change session as ended.
         this.setState({cellValueChanged: null});
+        this.pendingChanges = null;
     }
 
     onDisplayedColumnsChanged() {

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -113,10 +113,6 @@ function stringifyId(id) {
     return '{' + parts.join(',') + '}';
 }
 
-function is_undefined_or_null(obj) {
-    return typeof obj === 'undefined' || obj === null;
-}
-
 export default class DashAgGrid extends Component {
     constructor(props) {
         super(props);
@@ -932,7 +928,7 @@ export default class DashAgGrid extends Component {
             timestamp,
         };
         // Append it to current change session.
-        if (is_undefined_or_null(this.pendingCellValueChanges)) {
+        if (!this.pendingCellValueChanges) {
             this.pendingCellValueChanges = [newChange];
         } else {
             this.pendingCellValueChanges.push(newChange);
@@ -941,7 +937,7 @@ export default class DashAgGrid extends Component {
 
     afterCellValueChanged() {
         // Guard against multiple invocations of the same change session.
-        if (is_undefined_or_null(this.pendingCellValueChanges)) {
+        if (!this.pendingCellValueChanges) {
             return;
         }
         // Send update(s) for current change session to Dash.

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -66,7 +66,7 @@ const RESIZE_DEBOUNCE_MS = 200;
 const COL_RESIZE_DEBOUNCE_MS = 500;
 
 // Time between syncing cell value changes with Dash
-const CELL_VALUE_CHANGED_DEBOUNCE_MS = 10;
+const CELL_VALUE_CHANGED_DEBOUNCE_MS = 100;
 
 const xssMessage = (context) => {
     console.error(

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -66,7 +66,7 @@ const RESIZE_DEBOUNCE_MS = 200;
 const COL_RESIZE_DEBOUNCE_MS = 500;
 
 // Time between syncing cell value changes with Dash
-const CELL_VALUE_CHANGED_DEBOUNCE_MS = 100;
+const CELL_VALUE_CHANGED_DEBOUNCE_MS = 1;
 
 const xssMessage = (context) => {
     console.error(

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -65,6 +65,9 @@ const RESIZE_DEBOUNCE_MS = 200;
 // Rate-limit for updating columnState when interacting with the grid
 const COL_RESIZE_DEBOUNCE_MS = 500;
 
+// Time between syncing cell value changes with Dash
+const CELL_VALUE_CHANGED_DEBOUNCE_MS = 1;
+
 const xssMessage = (context) => {
     console.error(
         context,
@@ -119,6 +122,7 @@ export default class DashAgGrid extends Component {
         this.onCellClicked = this.onCellClicked.bind(this);
         this.onCellDoubleClicked = this.onCellDoubleClicked.bind(this);
         this.onCellValueChanged = this.onCellValueChanged.bind(this);
+        this.afterCellValueChanged = this.afterCellValueChanged.bind(this);
         this.onRowDataUpdated = this.onRowDataUpdated.bind(this);
         this.onFilterChanged = this.onFilterChanged.bind(this);
         this.onSortChanged = this.onSortChanged.bind(this);
@@ -912,20 +916,42 @@ export default class DashAgGrid extends Component {
         node,
     }) {
         const timestamp = Date.now();
+        // Collect new change.
+        const newChange = {
+            rowIndex,
+            rowId: node.id,
+            data,
+            oldValue,
+            value,
+            colId,
+            timestamp,
+        }
+        // Append it to current change session.
+        let pendingChanges = this.state.cellValueChanged;
+        if(pendingChanges === undefined){
+            pendingChanges = [newChange]
+        }
+        else{
+            pendingChanges.push(newChange)
+        }
+        this.setState({cellValueChanged: pendingChanges})
+    }
+
+    afterCellValueChanged() {
+        const cellValueChanged = this.state.cellValueChanged;
+        // Guard against multiple invocations of the same change session.
+        if(cellValueChanged === undefined){
+            return;
+        }
+        // Send update(s) for current change session to Dash.
         const virtualRowData = this.virtualRowData();
         this.props.setProps({
-            cellValueChanged: {
-                rowIndex,
-                rowId: node.id,
-                data,
-                oldValue,
-                value,
-                colId,
-                timestamp,
-            },
+            cellValueChanged: cellValueChanged,
             virtualRowData,
         });
         this.syncRowData();
+        // Mark current change session as ended.
+        this.setState({cellValueChanged: undefined})
     }
 
     onDisplayedColumnsChanged() {
@@ -1325,7 +1351,11 @@ export default class DashAgGrid extends Component {
                     onSelectionChanged={this.onSelectionChanged}
                     onCellClicked={this.onCellClicked}
                     onCellDoubleClicked={this.onCellDoubleClicked}
-                    onCellValueChanged={this.onCellValueChanged}
+                    onCellValueChanged={debounce(
+                        this.afterCellValueChanged,
+                        CELL_VALUE_CHANGED_DEBOUNCE_MS, // FIXME: SET VARIABLE(!)
+                        this.onCellValueChanged,
+                    )}
                     onFilterChanged={this.onFilterChanged}
                     onSortChanged={this.onSortChanged}
                     onRowDragEnd={this.onSortChanged}

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -928,10 +928,9 @@ export default class DashAgGrid extends Component {
         };
         // Append it to current change session.
         let pendingChanges = this.state.cellValueChanged;
-        if(typeof pendingChanges === 'undefined' || pendingChanges === null){
+        if (typeof pendingChanges === 'undefined' || pendingChanges === null) {
             pendingChanges = [newChange];
-        }
-        else{
+        } else {
             pendingChanges.push(newChange);
         }
         this.setState({cellValueChanged: pendingChanges});
@@ -940,7 +939,10 @@ export default class DashAgGrid extends Component {
     afterCellValueChanged() {
         const {cellValueChanged} = this.state;
         // Guard against multiple invocations of the same change session.
-        if(typeof cellValueChanged === 'undefined' || cellValueChanged === null){
+        if (
+            typeof cellValueChanged === 'undefined' ||
+            cellValueChanged === null
+        ) {
             return;
         }
         // Send update(s) for current change session to Dash.
@@ -1354,7 +1356,7 @@ export default class DashAgGrid extends Component {
                     onCellValueChanged={debounce(
                         this.afterCellValueChanged,
                         CELL_VALUE_CHANGED_DEBOUNCE_MS,
-                        this.onCellValueChanged,
+                        this.onCellValueChanged
                     )}
                     onFilterChanged={this.onFilterChanged}
                     onSortChanged={this.onSortChanged}

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -66,7 +66,7 @@ const RESIZE_DEBOUNCE_MS = 200;
 const COL_RESIZE_DEBOUNCE_MS = 500;
 
 // Time between syncing cell value changes with Dash
-const CELL_VALUE_CHANGED_DEBOUNCE_MS = 1;
+const CELL_VALUE_CHANGED_DEBOUNCE_MS = 10;
 
 const xssMessage = (context) => {
     console.error(

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -113,8 +113,8 @@ function stringifyId(id) {
     return '{' + parts.join(',') + '}';
 }
 
-function is_undefined_or_null(obj){
-    return typeof obj === 'undefined' || obj === null
+function is_undefined_or_null(obj) {
+    return typeof obj === 'undefined' || obj === null;
 }
 
 export default class DashAgGrid extends Component {
@@ -932,8 +932,7 @@ export default class DashAgGrid extends Component {
             timestamp,
         };
         // Append it to current change session.
-        if(is_undefined_or_null(this.pendingCellValueChanges
-        )) {
+        if (is_undefined_or_null(this.pendingCellValueChanges)) {
             this.pendingCellValueChanges = [newChange];
         } else {
             this.pendingCellValueChanges.push(newChange);
@@ -942,7 +941,7 @@ export default class DashAgGrid extends Component {
 
     afterCellValueChanged() {
         // Guard against multiple invocations of the same change session.
-        if(is_undefined_or_null(this.pendingCellValueChanges)) {
+        if (is_undefined_or_null(this.pendingCellValueChanges)) {
             return;
         }
         // Send update(s) for current change session to Dash.

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -113,6 +113,10 @@ function stringifyId(id) {
     return '{' + parts.join(',') + '}';
 }
 
+function is_undefined_or_null(obj){
+    return typeof obj === 'undefined' || obj === null
+}
+
 export default class DashAgGrid extends Component {
     constructor(props) {
         super(props);
@@ -928,33 +932,27 @@ export default class DashAgGrid extends Component {
             timestamp,
         };
         // Append it to current change session.
-        if (typeof this.pendingChanges === 'undefined' || this.pendingChanges === null) {
-            this.pendingChanges = [newChange];
+        if(is_undefined_or_null(this.pendingCellValueChanges)) {
+            this.pendingCellValueChanges = [newChange];
         } else {
-            this.pendingChanges.push(newChange);
+            this.pendingCellValueChanges.push(newChange);
         }
-        this.setState({cellValueChanged: this.pendingChanges});
     }
 
     afterCellValueChanged() {
-        const {cellValueChanged} = this.state;
         // Guard against multiple invocations of the same change session.
-        if (
-            typeof cellValueChanged === 'undefined' ||
-            cellValueChanged === null
-        ) {
+        if(is_undefined_or_null(this.pendingCellValueChanges)) {
             return;
         }
         // Send update(s) for current change session to Dash.
         const virtualRowData = this.virtualRowData();
         this.props.setProps({
-            cellValueChanged: cellValueChanged,
+            cellValueChanged: this.pendingCellValueChanges,
             virtualRowData,
         });
         this.syncRowData();
         // Mark current change session as ended.
-        this.setState({cellValueChanged: null});
-        this.pendingChanges = null;
+        this.pendingCellValueChanges = null;
     }
 
     onDisplayedColumnsChanged() {

--- a/src/lib/utils/debounce.js
+++ b/src/lib/utils/debounce.js
@@ -7,7 +7,7 @@ export default function debounce(fn, wait, onDebounce) {
         const delay = Math.min(now - lastTimestamp, wait);
 
         if (onDebounce) {
-            onDebounce(...args)
+            onDebounce(...args);
         }
         if (handle) {
             clearTimeout(handle);

--- a/src/lib/utils/debounce.js
+++ b/src/lib/utils/debounce.js
@@ -1,4 +1,4 @@
-export default function debounce(fn, wait) {
+export default function debounce(fn, wait, onDebounce) {
     let lastTimestamp = 0;
     let handle;
 
@@ -6,6 +6,9 @@ export default function debounce(fn, wait) {
         const now = Date.now();
         const delay = Math.min(now - lastTimestamp, wait);
 
+        if (onDebounce) {
+            onDebounce(...args)
+        }
         if (handle) {
             clearTimeout(handle);
         }

--- a/tests/test_cell_value_changed.py
+++ b/tests/test_cell_value_changed.py
@@ -117,6 +117,7 @@ def test_cv001_cell_value_changed_multi(dash_duo):
                 defaultColDef={"editable": True},
                 id="grid",
                 getRowId="params.data.nation",
+                dashGridOptions={'editType':'fullRow'}
             ),
             html.Div(id="log")
         ]
@@ -138,12 +139,12 @@ def test_cv001_cell_value_changed_multi(dash_duo):
     grid.wait_for_cell_text(0, 0, "South Korea")
 
     # Test single event.
-    grid.get_cell(0, 1).send_keys("X")
+    grid.get_cell(0, 1).send_keys("50")
     grid.get_cell(1, 2).click()
     dash_duo.wait_for_text_to_equal('#log', "1")
 
     # Test multi event.
-    grid.get_cell(0, 1).send_keys("Y")
-    grid.get_cell(0, 2).send_keys("Y")
+    grid.get_cell(0, 1).send_keys("20")
+    grid.get_cell_editing_input(0, 2).send_keys("20")
     grid.get_cell(1, 2).click()
     dash_duo.wait_for_text_to_equal('#log', "2")

--- a/tests/test_cell_value_changed.py
+++ b/tests/test_cell_value_changed.py
@@ -45,11 +45,14 @@ def test_cv001_cell_value_changed(dash_duo):
     app.clientside_callback(
         """function addToHistory(changes) {
             if (changes) {
-                data = changes[0];
-                reloadData = {...data.data}
-                reloadData[data.colId] = data.oldValue
-                newData = [{Key: data.rowId, Column: data.colId, OldValue: data.oldValue, NewValue: data.value,
-                    reloadData}]
+                newData = []
+                for (let i = 0; i < changes.length; i++) {
+                    data = changes[i];
+                    reloadData = {...data.data};
+                    reloadData[data.colId] = data.oldValue;
+                    newData.push({Key: data.rowId, Column: data.colId, OldValue: data.oldValue, 
+                    NewValue: data.value, reloadData});
+                }
                 return {'add': newData}
             }
             return window.dash_clientside.no_update
@@ -76,28 +79,25 @@ def test_cv001_cell_value_changed(dash_duo):
 
     grid = utils.Grid(dash_duo, "information")
     hist = utils.Grid(dash_duo, "history")
-
     grid.wait_for_cell_text(0, 0, "South Korea")
 
-    ### testing history
+    # Test history.
     grid.get_cell(0, 1).send_keys("50")
     grid.get_cell(1, 2).click()
-
     hist.wait_for_rendered_rows(1)
 
+    # Test single event.
     hist.element_click_cell_checkbox(0, 0)
     hist.wait_for_rendered_rows(0)
-
     grid.get_cell(0, 1).send_keys("50")
     grid.get_cell(1, 2).click()
-
     hist.wait_for_rendered_rows(1)
 
-    ## twice for good measure
+    # Test multiple events (here 3).
     hist.element_click_cell_checkbox(0, 0)
     hist.wait_for_rendered_rows(0)
-
     grid.get_cell(0, 1).send_keys("50")
+    grid.get_cell(0, 2).send_keys("50")
+    grid.get_cell(0, 3).send_keys("50")
     grid.get_cell(1, 2).click()
-
-    hist.wait_for_rendered_rows(1)
+    hist.wait_for_rendered_rows(3)

--- a/tests/test_cell_value_changed.py
+++ b/tests/test_cell_value_changed.py
@@ -43,8 +43,9 @@ def test_cv001_cell_value_changed(dash_duo):
     )
 
     app.clientside_callback(
-        """function addToHistory(data) {
-            if (data) {
+        """function addToHistory(changes) {
+            if (changes) {
+                data = changes[0];
                 reloadData = {...data.data}
                 reloadData[data.colId] = data.oldValue
                 newData = [{Key: data.rowId, Column: data.colId, OldValue: data.oldValue, NewValue: data.value,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -170,6 +170,11 @@ class Grid:
             f'#{self.id} .ag-row[row-index="{row}"] .ag-cell[aria-colindex="{col + 1}"]'
         )
 
+    def get_cell_editing_input(self, row, col):
+        return self.dash_duo.find_element(
+            f'#{self.id} .ag-row[row-index="{row}"] .ag-cell[aria-colindex="{col + 1}"] .ag-cell-editor input'
+        )
+
     def get_row(self, row):
         return self.dash_duo.find_element(f'#{self.id} .ag-row[row-index="{row}"]')
 


### PR DESCRIPTION
Currently, the `cellValueChanged` events are propagated to Dash one-by-one. This becomes a problem in cases, where events are fires faster than Dash can handle them, e.g. when pasting multiple cells into the grid. For these cases, only the first event triggers a Dash callback, with all other changes lost. 

This PR changes the event collection mechanism to include all events fired within a specific time window (with the length currently defined by `CELL_VALUE_CHANGED_DEBOUNCE_MS = 1`). By making the window large enough that all events in e.g. a multi cell paste operation can be processed (initial tests indicate that 1 ms is sufficient), all changes can be propagted to Dash. Hence the callback will now receieve a _list_ of change events rather than a _single_ change event.

Here is a small example that demonstrates the usage,

```python
import pandas as pd
import dash_ag_grid as dag
from dash import Dash, Input, Output, html, callback

df = pd.read_csv(
    "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
)

app = Dash(__name__)
app.layout = html.Div(
    [
        dag.AgGrid(
            id="grid",
            rowData=df.to_dict("records"),
            columnDefs=[{"field": i} for i in df.columns],
            defaultColDef={"resizable": True, "sortable": True, "filter": True, "editable": True},
            dashGridOptions={
                "enableRangeSelection": True,
            },
            enableEnterpriseModules=True,
            columnSize="sizeToFit",
        ),
        html.Div(id="dummy"),
    ],
)


@callback(
    Output("dummy", "children"),
    Input("grid", "cellValueChanged")
)
def update(cell_changed):
    return str(cell_changed)


if __name__ == "__main__":
    app.run(debug=True)
```

Copy-pasting (the whole) row 0 to row 4 will yield the following output with the main branch,

```bash
{'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 6, 'value': '8', 'colId': 'total', 'timestamp': 1703846436733}
```

With the updates propose in the PR, the output will be,

```bash
[{'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 'Aleksey Nemov', 'value': 'Michael Phelps', 'colId': 'athlete', 'timestamp': 1703846303490}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 24, 'value': '23', 'colId': 'age', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 'Russia', 'value': 'United States', 'colId': 'country', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 2000, 'value': '2008', 'colId': 'year', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': '1/10/2000', 'value': '24/08/2008', 'colId': 'date', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 'Gymnastics', 'value': 'Swimming', 'colId': 'sport', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 2, 'value': '8', 'colId': 'gold', 'timestamp': 1703846303491}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 1, 'value': '0', 'colId': 'silver', 'timestamp': 1703846303493}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 3, 'value': '0', 'colId': 'bronze', 'timestamp': 1703846303493}, {'rowIndex': 4, 'rowId': '4', 'data': {'athlete': 'Michael Phelps', 'age': '23', 'country': 'United States', 'year': '2008', 'date': '24/08/2008', 'sport': 'Swimming', 'gold': '8', 'silver': '0', 'bronze': '0', 'total': '8'}, 'oldValue': 6, 'value': '8', 'colId': 'total', 'timestamp': 1703846303493}]
```

Currently, the time window size is hardcoded, but it could also be changed to be a property of the grid so that users get more fine-grained control. Please let me know, if this approach is preferred or not.