### PR TITLE
Update getApiAsync to allow for a longer timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 
 ## unreleased
 
+### Changed
+ - [#273](https://github.com/plotly/dash-ag-grid/pull/273) increased the timeout for `getApiAsync` to 2 minutes.
+
 ### Added
   - [#270](https://github.com/plotly/dash-ag-grid/pull/270)
     - support for `eventListeners` to be added to the grid that get loaded upon `gridReady`

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -762,15 +762,16 @@ const _getAsync =
         // which does the right thing because clearly no grid is initialized yet!
         var api = apiGetters[flavor]?.(id);
         const delay = (ms) => new Promise((res) => setTimeout(res, ms));
-        let count = 0;
+        const startTime = Date.now();
+        const maxDelay = 120000;
         let pause = 1;
         const increase = 1.5;
         while (!api) {
             await delay(pause);
             pause *= increase;
+            pause = Math.min(pause, 1000)
             api = apiGetters[flavor]?.(id);
-            count++;
-            if (count > trycount) {
+            if (Date.now() > startTime + maxDelay) {
                 break;
             }
         }

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -753,33 +753,31 @@ const _get = (flavor) => (id) => {
         `no grid found, or grid is not initialized yet, with id: ${id}`
     );
 };
-const _getAsync =
-    (flavor) =>
-    async (id) => {
-        // optional chaining so before the fragment exists it'll just return undefined
-        // which does the right thing because clearly no grid is initialized yet!
-        var api = apiGetters[flavor]?.(id);
-        const delay = (ms) => new Promise((res) => setTimeout(res, ms));
-        const startTime = Date.now();
-        const maxDelay = 120000;
-        let maxIncrement = 1000;
-        let pause = 1;
-        const increase = 1.5;
-        while (!api) {
-            await delay(pause);
-            pause *= increase;
-            pause = Math.min(pause, maxIncrement)
-            api = apiGetters[flavor]?.(id);
-            if (Date.now() > startTime + maxDelay) {
-                break;
-            }
+const _getAsync = (flavor) => async (id) => {
+    // optional chaining so before the fragment exists it'll just return undefined
+    // which does the right thing because clearly no grid is initialized yet!
+    var api = apiGetters[flavor]?.(id);
+    const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+    const startTime = Date.now();
+    const maxDelay = 120000;
+    const maxIncrement = 1000;
+    let pause = 1;
+    const increase = 1.5;
+    while (!api) {
+        await delay(pause);
+        pause *= increase;
+        pause = Math.min(pause, maxIncrement);
+        api = apiGetters[flavor]?.(id);
+        if (Date.now() > startTime + maxDelay) {
+            break;
         }
-        if (api) {
-            return api;
-        }
-        throw new Error(
-            `no grid found, or grid is not initialized yet, with id: ${id}`
-        );
-    };
+    }
+    if (api) {
+        return api;
+    }
+    throw new Error(
+        `no grid found, or grid is not initialized yet, with id: ${id}`
+    );
+};
 export const getApi = _get('getApi');
 export const getApiAsync = _getAsync('getApi');

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -742,8 +742,6 @@ export const defaultProps = DashAgGrid.defaultProps;
 
 export const apiGetters = {};
 
-const DEFAULTTRYCOUNT = 20;
-
 const _get = (flavor) => (id) => {
     // optional chaining so before the fragment exists it'll just return undefined
     // which does the right thing because clearly no grid is initialized yet!
@@ -757,19 +755,20 @@ const _get = (flavor) => (id) => {
 };
 const _getAsync =
     (flavor) =>
-    async (id, trycount = DEFAULTTRYCOUNT) => {
+    async (id) => {
         // optional chaining so before the fragment exists it'll just return undefined
         // which does the right thing because clearly no grid is initialized yet!
         var api = apiGetters[flavor]?.(id);
         const delay = (ms) => new Promise((res) => setTimeout(res, ms));
         const startTime = Date.now();
         const maxDelay = 120000;
+        let maxIncrement = 1000;
         let pause = 1;
         const increase = 1.5;
         while (!api) {
             await delay(pause);
             pause *= increase;
-            pause = Math.min(pause, 1000)
+            pause = Math.min(pause, maxIncrement)
             api = apiGetters[flavor]?.(id);
             if (Date.now() > startTime + maxDelay) {
                 break;


### PR DESCRIPTION
Allow for up to 2 minutes before `getApiAsync` fails.  