### PR TITLE
Fix scroll to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 ### Fixed
  - [#314](https://github.com/plotly/dash-ag-grid/pull/314)
    - locking selenium for tests that were failing due to missing import
+ - [#313](https://github.com/plotly/dash-ag-grid/pull/313)
+   - fixing issue where `scrollTo` was defaulting to not reset the value
+   - fixing side issue where `cellDoubleClicked` was forcing the grid to rerender
 
 
 ## [31.2.0] - 2024-02-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
  - [#314](https://github.com/plotly/dash-ag-grid/pull/314)
    - locking selenium for tests that were failing due to missing import
  - [#313](https://github.com/plotly/dash-ag-grid/pull/313)
-   - fixing issue where `scrollTo` was defaulting to not reset the value
+   - [#312](https://github.com/plotly/dash-ag-grid/issues/312) fixing issue where `scrollTo` was defaulting to not reset the value
+     - to maintain scroll position during a grid rerender, be sure to use `getRowId`
    - fixing side issue where `cellDoubleClicked` was forcing the grid to rerender
 
 

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1203,7 +1203,7 @@ export default class DashAgGrid extends Component {
         }
     }
 
-    scrollTo(reset = false) {
+    scrollTo(reset = true) {
         const {gridApi} = this.state;
         const {scrollTo, setProps, getRowId} = this.props;
         if (!gridApi) {

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -700,7 +700,7 @@ export default class DashAgGrid extends Component {
             }
 
             if (scrollTo) {
-                this.scrollTo(scrollTo);
+                this.scrollTo(false);
                 propsToSet.scrollTo = null;
             }
 

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -328,6 +328,7 @@ export const PROPS_NOT_FOR_AG_GRID = [
     'virtualRowData',
     'cellValueChanged',
     'cellClicked',
+    'cellDoubleClicked',
     'getRowRequest',
     'getRowResponse',
     'getDetailRequest',
@@ -364,6 +365,7 @@ export const OMIT_PROP_RENDER = [
     'cellClicked',
     'paginationInfo',
     'cellRendererData',
+    'cellDoubleClicked'
 ];
 
 /**

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -365,7 +365,7 @@ export const OMIT_PROP_RENDER = [
     'cellClicked',
     'paginationInfo',
     'cellRendererData',
-    'cellDoubleClicked'
+    'cellDoubleClicked',
 ];
 
 /**


### PR DESCRIPTION
Fixing issue with `scrollTo` not being reset after being used.

```
import dash_ag_grid as dag
from dash import Dash, html, dcc, Input, Output, State, callback
import pandas as pd
import dash_bootstrap_components as dbc

app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])


df = pd.read_csv(
    "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
)

columnDefs = [
    {"headerName": "Row", "valueGetter": {"function": "params.node.rowIndex", 'pinned': True}}
] + [{"field": c} for c in df.columns]

app.layout = dbc.Container(
    [
        dbc.Row(
            [
                dbc.Col(
                    [
                        dbc.Label("Row index"),
                        dbc.Input(
                            id="row-index-scroll-to",
                            type="number",
                            min=0,
                            max=df.shape[0] - 1,
                            step=1,
                        ),
                        dbc.Label("Row Position"),
                        dcc.Dropdown(
                            options=["top", "bottom", "middle"],
                            id="row-position-scroll-to",
                        ),
                    ]
                ),
                dbc.Col(
                    [
                        dbc.Label("Column"),
                        dcc.Dropdown(options=df.columns, id="column-scroll-to"),
                        dbc.Label("Column Position"),
                        dcc.Dropdown(
                            options=["auto", "start", "middle", "end"],
                            id="column-position-scroll-to",
                        ),
                    ]
                ),
            ],
            className="mb-2",
        ),
        dag.AgGrid(
            id="grid-scroll-to",
            columnDefs=columnDefs,
            rowData=df.to_dict("records"),
            columnSize="sizeToFit",
            defaultColDef={"minWidth": 150},
            dashGridOptions={"animateRows": False}
        ),
        html.Div(id="out-scroll-to"),
    ],
    fluid=True,
)


@callback(
    Output("out-scroll-to", "children"),
    Input("grid-scroll-to", "scrollTo"),
)
def show_scroll(scroll):
    return  f"scroll_to = {str(scroll)}"


@callback(
    Output("grid-scroll-to", "scrollTo"),
    Input("row-index-scroll-to", "value"),
    Input("column-scroll-to", "value"),
    Input("row-position-scroll-to", "value"),
    Input("column-position-scroll-to", "value"),
    State("grid-scroll-to", "scrollTo"),
)
def scroll_to_row_and_col(row_index, column, row_position, column_position, scroll_to):
    if not scroll_to:
        scroll_to = {}
    scroll_to["rowIndex"] = row_index
    scroll_to["column"] = column
    scroll_to["rowPosition"] = row_position
    scroll_to["columnPosition"] = column_position
    return scroll_to


if __name__ == "__main__":
    app.run(debug=True)

```

Use the `scrollTo` and then double-click in a cell after scrolling down or up, you will no longer jump to the last `scrollTo` position