### PR TITLE
Automatically publish release to PyPi after publishing Github Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build package
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      node-version:
+        required: true
+        type: string
+
+jobs:
+  build-and-validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Setup dependencies
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
+          source .venv/bin/activate
+          uv pip install ".[dev]"
+          npm i
+        shell: bash
+      - name: Build package
+        run: |
+          source .venv/bin/activate
+          npm run build
+        shell: bash
+      - name: Generate distribution
+        run: |
+          source .venv/bin/activate
+          npm run dist
+          npm pack && mv *.tgz dist/
+        shell: bash
+      - name: Validate distribution
+        run: |
+          uv venv test-dist
+          source test-dist/bin/activate
+          WHL_FILE=$(ls dist/*.whl)
+          uv pip install "${WHL_FILE}[dev]"
+          npm run test
+        shell: bash

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write  # Mandatory for trusted publishing
+      contents: read   # Required to access repository files
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Reuse Build and Validate Workflow
+      uses: ./.github/workflows/build.yml
+      with:
+        python-version: '3.10'
+        node-version: 'v18.16.0'
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,41 +13,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - name: Reuse Build and Validate Workflow
+        uses: ./.github/workflows/build.yml
         with:
-          node-version: "v18.16.0"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Setup dependencies
-        # Set up the virtual environment and install dev dependencies (JS & Python)
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv
-          source .venv/bin/activate
-          uv pip install ".[dev]"
-          npm i
-        shell: bash
-      - name: Build package
-        run: |
-          source .venv/bin/activate
-          npm run build
-        shell: bash
-      - name: Generate distribution
-        # Run setup.py to generate the distribution
-        run: |
-          source .venv/bin/activate
-          npm run dist
-          npm pack && mv *.tgz dist/
-      - name: Validate distribution
-        # Run tests again using the generated wheel file
-        run: |
-          uv venv test-dist
-          source test-dist/bin/activate
-          WHL_FILE=$(ls dist/*.whl)
-          uv pip install "${WHL_FILE}[dev]"
-          npm run test
-        shell: bash
+          python-version: '3.10'
+          node-version: 'v18.16.0'
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*.whl,dist/*.tar.gz"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,50 +51,19 @@ Commit this - either via a PR or directly to the main branch. Then you can creat
 ```
 npm run dist
 ```
-See [PyPA](https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project)
-for more information. At this point you can test the build. The best way is to make a virtual env in another directory, install the wheel you just built, and run one of the demo apps, something like:
-```
-cd ../my_test
-python -m venv venv
-. venv/bin/activate
-pip install -e ".[dev, docs]"
-```
 
-And run the tests:
-```
-pytest
-```
+### Publish a new release
+A Github release with package build files is automatically generated when a new tag starting with `v*` is pushed.
 
-Create a new distribution with:
-```
-npm run dist
-```
+Once a Github release is published, the build is re-generated and pushed to PyPi.
 
-It doesn't need to be tested extensively, just enough to know that the grid loads with no errors and you've built the right version of the code. If the app looks good, use [`twine`](https://pypi.org/project/twine/) to upload these to PyPI:
-```
-# back in the dash-ag-grid directory
-twine upload dist/*
-```
-Now you can go back to the test directory, install from PyPI, ensure you get the expected version, and test again:
-```
-pip uninstall dash-ag-grid
-pip install dash-ag-grid
-python demo_stock_portfolio.py
-```
-
-We also publish the JavaScript build to NPM, so `unpkg` has the bundles if users set `serve_locally=False`. First make a test of the NPM package, verify that its contents are reasonable:
-```
-npm pack
-```
-Then publish:
-```
-npm publish
-```
-Now create a git tag:
+Create a git tag:
 ```
 git tag -a 'v31.0,1' -m 'v31.0.1'
 git push --tags
 ```
-And create a new [GitHub release](https://github.com/plotly/dash-ag-grid/releases) linked to this tag, titled the same as the tag name (`v31.0.1` etc), with the exact changelog entry for this release as the description, and attach the built packages (both files in the `dist/` folder) to the release.
+Wait for the "Generate release" CI job to complete, then check the releases tab to move the release from "Draft" to "Published". Make sure to copy in the Changelog!
 
-Lastly, announce the release in Slack, in both the `#dash-product` and `#community-ag-grid` channels. You're done!
+When the release is published to Github, it's automatically pushed to PyPi as well. You're done 🎉
+
+Finally, announce the release in Slack, in both the `#dash-product` and `#community-ag-grid` channels. You're done!


### PR DESCRIPTION
I've added the right secret to this repository so we should be good to go once this is merged, and can verify everything works at the next release.