### PR TITLE
Seperate reusable workflow into named job

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml # Build the package artifacts
+    with:
+      python-version: '3.10'
+      node-version: 'v18.16.0'
+
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
@@ -13,15 +19,12 @@ jobs:
     permissions:
       id-token: write  # Mandatory for trusted publishing
       contents: read   # Required to access repository files
+    needs: build  # Waits for the build job to finish
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Reuse Build and Validate Workflow
-      uses: ./.github/workflows/build.yml
-      with:
-        python-version: '3.10'
-        node-version: 'v18.16.0'
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,28 @@
 name: Generate release
-
 permissions:
   contents: read
-
 on:
   push:
     tags:
       - "v*"
   workflow_dispatch:
-
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml # Build the package artifacts
+    with:
+      python-version: '3.10'
+      node-version: 'v18.16.0'
+
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - name: Reuse Build and Validate Workflow
-        uses: ./.github/workflows/build.yml
-        with:
-          python-version: '3.10'
-          node-version: 'v18.16.0'
-      - uses: ncipollo/release-action@v1
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Upload GitHub Release
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*.whl,dist/*.tar.gz"
-          draft: true
+          draft: true  


### PR DESCRIPTION
Separates into the `job` syntax rather than `steps`