### PR TITLE
Share artifacts between jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,8 @@ jobs:
           uv pip install "${WHL_FILE}[dev]"
           npm run test
         shell: bash
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-distributions
+          path: dist/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: package-distributions
+          path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: package-distributions
+          path: dist/
       - name: Upload GitHub Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
We need to manually upload and download the artifacts from build to release/publish steps. 