### PR TITLE
Use Trusted Publisher rather than API keys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,7 @@ jobs:
           path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-      
+        
       - name: Download npm package
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
I have configured https://docs.pypi.org/trusted-publishers/adding-a-publisher/ in PyPI which means we no longer need API keys here.