### PR TITLE
fix: bring `more_examples` up to date and minor formatting fixes in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 - [#328](https://github.com/plotly/dash-ag-grid/pull/328) fixed issue where `getRowStyle` wast able to be passed as a complete function
 
 ### Changed
-- [#328](https://github.com/plotly/dash-ag-grid/pull/328) 
+- [#328](https://github.com/plotly/dash-ag-grid/pull/328)
   - bumping to v`32.3` for the grid
   - the grid checks if updates are from an internal source (3.0.2 dash) and will selectively rerender if so
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Dash AG Grid Contributing Guide
 
 Dash AG Grid welcomes community contributions!
@@ -7,25 +6,35 @@ If you have identified a bug or have an idea for a new feature, it's best to sta
 
 If you have questions, please ask on the [Dash Community Forum](https://community.plotly.com/). rather than using GitHub issues.
 
-
-### Developing in this repo
+### Developing in This Repo
 
 Make sure you have Dash installed with dev and testing extras:
+
 ```
 pip install dash[dev,testing]
 ```
+
 Build the component (from the root of this repo):
+
 ```
 npm i
 npm run build
 ```
+
 Now install the component in development mode:
+
 ```
 $ pip install -e .
 ```
+
 In development mode, Python uses the files in this directory when you import the package. So you can write a testing app in another folder, and whenever you change some code and rebuild the component here it will update in your testing app.
 
+#### The Build Process
+
+Dash AG Grid uses [`dash-generate-components`](https://dash.plotly.com/dash-3-for-component-developers) to read the JavaScript file `src/lib/components/AgGrid.react.js` and generate `dash_ag_grid/AgGrid.py` (along with similar files for R and Julia). `AgGrid.py` only changes when the React component's interface changes, so do not be surprised if internal changes to `AgGrid.react.js` do not result in changes to `AgGrid.py`.
+
 ### Versioning
+
 We follow a strict versioning system aligned with the underlying Ag Grid version, but also reserving the
 patch number for updates to the Dash grid.
 
@@ -39,31 +48,36 @@ As a user, you can always check the underlying Ag Grid version with `dash_ag_gri
 
 For maintainers, when issuing new releases ensure that the version bump of Dash Ag Grid follows this convention. This can be verified after a build by using `npm run pre-flight-dag-version` or `python test_versioning.py`. This is validated during the `npm run dist`
 
-### Create a production build
+### Create a Production Build
 
 Update the package version in `package.json` and `CHANGELOG.md` and ensure the changelog lists all the important updates. Then reinstall (so `package-lock.json` gets the new version) and rebuild:
+
 ```
 npm i
 npm run build
 ```
 
 Commit this - either via a PR or directly to the main branch. Then you can create source and wheel distributions in the generated `dist/` folder, after emptying out any previous builds:
+
 ```
 npm run dist
 ```
 
-### Publish a new release
+### Publish a New Release
+
 A Github release with package build files is automatically generated when a new tag starting with `v*` is pushed.
 
 Once a Github release is published, the build is re-generated and pushed to PyPi.
 
 Create a git tag:
+
 ```
 git tag -a 'v31.0,1' -m 'v31.0.1'
 git push --tags
 ```
-Wait for the "Generate release" CI job to complete, then check the releases tab to move the release from "Draft" to "Published". Make sure to copy in the Changelog!
 
-When the release is published to Github, it's automatically pushed to PyPi as well. You're done 🎉
+Wait for the "Generate release" CI job to complete, then check the releases tab to move the release from "Draft" to "Published". Make sure to copy in the Changelog.
+
+When the release is published to Github, it's automatically pushed to PyPi as well.
 
 Finally, announce the release in Slack, in both the `#dash-product` and `#community-ag-grid` channels. You're done!

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Dash AG Grid Documentation
+
+The documentation for this package has been incorporated into [the Dash documentation](https://dash.plotly.com/).
+This material is retained for historical reference only;
+please do not update it.

--- a/more_examples/README.md
+++ b/more_examples/README.md
@@ -1,0 +1,15 @@
+# Dash AG Grid Examples
+
+The examples for this package have been incorporated into [the Dash documentation](https://dash.plotly.com/).
+These examples are retained for historical reference only;
+please do not update them.
+Please note that the stock portfolio example is referenced in
+[this Medium article](https://medium.com/plotly/announcing-dash-ag-grid-fbb4a1c83e62).
+
+To run these examples:
+
+1.  Set up a development environment as described in [CONTRIBUTING.md](../CONTRIBUTING.md).
+1.  Install the dependencies in [requires-docs.txt](../requires-docs.txt)
+    (e.g., using `pip install -r requires-docs.txt`).
+1.  Run the application you are interested in
+    (e.g., `python more_examples/demo_stock_portfolio_dmc/app.py`).

--- a/more_examples/convert_units/app.py
+++ b/more_examples/convert_units/app.py
@@ -1,11 +1,7 @@
 """
 This app is an example of a custom number filter
 https://www.ag-grid.com/react-data-grid/filter-number/#custom-number-support
-
 """
-
-
-
 
 import dash_ag_grid as dag
 from dash import Dash, html
@@ -49,4 +45,4 @@ app.layout = html.Div(
 )
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/more_examples/demo_stock_portfolio_dmc/app.py
+++ b/more_examples/demo_stock_portfolio_dmc/app.py
@@ -162,15 +162,15 @@ grid = dag.AgGrid(
 
 candlestick = dmc.Card(dcc.Graph(id="candlestick"), withBorder=True)
 pie = dmc.Card(dcc.Graph(id="asset-allocation"), withBorder=True)
-header = dmc.Title("My Portfolio", order=1, align="center", p="xl", color="blue")
+header = dmc.Title("My Portfolio", order=1, ta="center", p="xl", c="blue")
 
 app.layout = dmc.MantineProvider(
     theme={"colorScheme": "dark"},
-    withGlobalStyles=True,
+    withGlobalClasses=True,
     children=html.Div(
     [
         header,
-        dmc.Grid([dmc.Col(candlestick, span=6), dmc.Col(pie, span=6)]),
+        dmc.Grid([dmc.GridCol(candlestick, span=6), dmc.GridCol(pie, span=6)]),
         html.Div(grid),
     ], style={"padding":12}
     )
@@ -227,7 +227,7 @@ def update_portfolio_stats(_, data):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=False)
+    app.run(debug=False)
 
 
 """

--- a/more_examples/figure_with_tooltip/app.py
+++ b/more_examples/figure_with_tooltip/app.py
@@ -101,7 +101,7 @@ app.layout = html.Div(
 )])
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)
 
 """
 Add the following to the dashAgGridComponents.js file in the /assets folder:

--- a/requires-docs.txt
+++ b/requires-docs.txt
@@ -8,4 +8,3 @@ dash-mantine-components
 dash-iconify
 colorlover
 statsmodels
-


### PR DESCRIPTION
1. Minor typography fixes in `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, and `CONTRIBUTING.md`.
1. Switch from `app.run_server` to `app.run` in `more_examples/*/*.py`.
1. Update use of Dash Mantine Compnents in `more_examples/demo_stock_portfolio_dmc/app.py`.

Note: filters do not appear to work correctly in `more_examples/convert_units` but that could be operator error - guidance would be appreciated.

Q: some of the examples in `more_examples` needed extra packages (listed below). Where should these be recorded?

-   `dash-bootstrap-components`
-   `dash-iconify`
-   `dash-mantine-components`
-   `pandas`
-   `yfinance`