### PR TITLE
Enforce a locale for cell formatting test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+
+@pytest.fixture
+def enforced_locale():
+    # Forces Chrome to use the `en-US` locale for tests, overriding any user-specified locale
+    os.environ["LANGUAGE"] = "en-US"

--- a/tests/test_cell_data_type_override.py
+++ b/tests/test_cell_data_type_override.py
@@ -4,7 +4,7 @@ import dash_ag_grid as dag
 from dash import Dash, html
 from . import utils
 
-def test_cd001_cell_data_types_override(dash_duo):
+def test_cd001_cell_data_types_override(enforced_locale, dash_duo):
     app = Dash(__name__)
 
     rowData = [


### PR DESCRIPTION
This PR fixes the cell formatting test which can fail if the browser's locale is not `en-US`.