### PR TITLE
Bugfix: race condition in paginationGoto prop

### DIFF
--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1433,7 +1433,6 @@ export function DashAgGrid(props) {
     useEffect(() => {
         if (
             gridApi &&
-            gridApi === prevGridApi &&
             (props.paginationGoTo || props.paginationGoTo === 0)
         ) {
             paginationGoTo();

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1431,10 +1431,7 @@ export function DashAgGrid(props) {
 
     // Handle pagination actions
     useEffect(() => {
-        if (
-            gridApi &&
-            (props.paginationGoTo || props.paginationGoTo === 0)
-        ) {
+        if (gridApi && (props.paginationGoTo || props.paginationGoTo === 0)) {
             paginationGoTo();
         }
     }, [props.paginationGoTo, gridApi, prevGridApi, paginationGoTo]);


### PR DESCRIPTION
This PR fixes a flaky test (and real world problem) where pagination might not be set as per the prop, depending on the order of operations in the component.