### PR TITLE
Remove Default Props

### DIFF
--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import LazyLoader from '../LazyLoader';
 import React, {lazy, Suspense, useState, useCallback, useEffect} from 'react';
 import {AllCommunityModule, ModuleRegistry} from 'ag-grid-community';
+import { pick } from 'ramda';
 
 // Register all community features
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -12,6 +13,25 @@ const RealAgGridEnterprise = lazy(LazyLoader.agGridEnterprise);
 function getGrid(enable) {
     return enable ? RealAgGridEnterprise : RealAgGrid;
 }
+
+export const defaultProps = {
+    className: '',
+    resetColumnState: false,
+    exportDataAsCsv: false,
+    selectAll: false,
+    deselectAll: false,
+    enableEnterpriseModules: false,
+    updateColumnState: false,
+    persisted_props: ['selectedRows'],
+    persistence_type: 'local',
+    suppressDragLeaveHidesColumns: true,
+    dangerously_allow_code: false,
+    rowModelType: 'clientSide',
+    dashGridOptions: {},
+    filterModel: {},
+    paginationGoTo: null,
+    selectedRows: [],
+};
 
 /**
  * Dash interface to AG Grid, a powerful tabular data component.
@@ -49,31 +69,23 @@ function DashAgGrid(props) {
 
     return (
         <Suspense fallback={null}>
-            <RealComponent parentState={state} {...props} />
+            <RealComponent parentState={state} {...defaultProps} {...props} />
         </Suspense>
     );
 }
 
+const REACT_VERSION_DASH2_COMPAT = 18.3;
+if (
+ parseFloat(React.version.substring(0, React.version.lastIndexOf('.'))) <
+    REACT_VERSION_DASH2_COMPAT
+) {
+    DashAgGrid.defaultProps = defaultProps;
+} else {
+    DashAgGrid.dashPersistence = pick(['persisted_props', 'persistence_type'],defaultProps);
+}
+
 DashAgGrid.dashRenderType = true;
 
-DashAgGrid.defaultProps = {
-    className: '',
-    resetColumnState: false,
-    exportDataAsCsv: false,
-    selectAll: false,
-    deselectAll: false,
-    enableEnterpriseModules: false,
-    updateColumnState: false,
-    persisted_props: ['selectedRows'],
-    persistence_type: 'local',
-    suppressDragLeaveHidesColumns: true,
-    dangerously_allow_code: false,
-    rowModelType: 'clientSide',
-    dashGridOptions: {},
-    filterModel: {},
-    paginationGoTo: null,
-    selectedRows: [],
-};
 DashAgGrid.propTypes = {
     /********************************
      * DASH PROPS
@@ -755,7 +767,6 @@ DashAgGrid.propTypes = {
 };
 
 export const propTypes = DashAgGrid.propTypes;
-export const defaultProps = DashAgGrid.defaultProps;
 
 export default DashAgGrid;
 

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1617,11 +1617,9 @@ export function DashAgGrid(props) {
     );
 }
 
-DashAgGrid.defaultProps = _defaultProps;
 DashAgGrid.propTypes = {parentState: PropTypes.any, ..._propTypes};
 
 export const propTypes = DashAgGrid.propTypes;
-export const defaultProps = DashAgGrid.defaultProps;
 
 var dagfuncs = (window.dash_ag_grid = window.dash_ag_grid || {});
 dagfuncs.useGridFilter = useGridFilter;

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -323,6 +323,8 @@ export const PASSTHRU_PROPS = ['rowData'];
  */
 export const PROPS_NOT_FOR_AG_GRID = [
     'children',
+    'dashRenderType',
+    'licenseKey',
     'setProps',
     'loading_state',
     'enableEnterpriseModules',
@@ -356,6 +358,7 @@ export const PROPS_NOT_FOR_AG_GRID = [
     'scrollTo',
     'eventListeners',
     'eventData',
+    'paginationInfo',
 ];
 
 /**


### PR DESCRIPTION
Removes default props, still allows for a global setting of the default props for easier use.

---

There was an issue that AnnMarie ran into with two tests locally:
- test_cs001_column_state
- test_el002_event_listener