### PR TITLE
Backport column state fix

### DIFF
--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import LazyLoader from '../LazyLoader';
 import React, {lazy, Suspense, useState, useCallback, useEffect} from 'react';
-import { pick } from 'ramda';
+import {pick} from 'ramda';
 
 const RealAgGrid = lazy(LazyLoader.agGrid);
 const RealAgGridEnterprise = lazy(LazyLoader.agGridEnterprise);
@@ -72,12 +72,15 @@ function DashAgGrid(props) {
 
 const REACT_VERSION_DASH2_COMPAT = 18.3;
 if (
- parseFloat(React.version.substring(0, React.version.lastIndexOf('.'))) <
+    parseFloat(React.version.substring(0, React.version.lastIndexOf('.'))) <
     REACT_VERSION_DASH2_COMPAT
 ) {
     DashAgGrid.defaultProps = defaultProps;
 } else {
-    DashAgGrid.dashPersistence = pick(['persisted_props', 'persistence_type'],defaultProps);
+    DashAgGrid.dashPersistence = pick(
+        ['persisted_props', 'persistence_type'],
+        defaultProps
+    );
 }
 
 DashAgGrid.dashRenderType = true;

--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import LazyLoader from '../LazyLoader';
 import React, {lazy, Suspense, useState, useCallback, useEffect} from 'react';
+import { pick } from 'ramda';
 
 const RealAgGrid = lazy(LazyLoader.agGrid);
 const RealAgGridEnterprise = lazy(LazyLoader.agGridEnterprise);
@@ -8,6 +9,25 @@ const RealAgGridEnterprise = lazy(LazyLoader.agGridEnterprise);
 function getGrid(enable) {
     return enable ? RealAgGridEnterprise : RealAgGrid;
 }
+
+export const defaultProps = {
+    className: 'ag-theme-alpine',
+    resetColumnState: false,
+    exportDataAsCsv: false,
+    selectAll: false,
+    deselectAll: false,
+    enableEnterpriseModules: false,
+    updateColumnState: false,
+    persisted_props: ['selectedRows'],
+    persistence_type: 'local',
+    suppressDragLeaveHidesColumns: true,
+    dangerously_allow_code: false,
+    rowModelType: 'clientSide',
+    dashGridOptions: {},
+    filterModel: {},
+    paginationGoTo: null,
+    selectedRows: [],
+};
 
 /**
  * Dash interface to AG Grid, a powerful tabular data component.
@@ -45,31 +65,23 @@ function DashAgGrid(props) {
 
     return (
         <Suspense fallback={null}>
-            <RealComponent parentState={state} {...props} />
+            <RealComponent parentState={state} {...defaultProps} {...props} />
         </Suspense>
     );
 }
 
+const REACT_VERSION_DASH2_COMPAT = 18.3;
+if (
+ parseFloat(React.version.substring(0, React.version.lastIndexOf('.'))) <
+    REACT_VERSION_DASH2_COMPAT
+) {
+    DashAgGrid.defaultProps = defaultProps;
+} else {
+    DashAgGrid.dashPersistence = pick(['persisted_props', 'persistence_type'],defaultProps);
+}
+
 DashAgGrid.dashRenderType = true;
 
-DashAgGrid.defaultProps = {
-    className: 'ag-theme-alpine',
-    resetColumnState: false,
-    exportDataAsCsv: false,
-    selectAll: false,
-    deselectAll: false,
-    enableEnterpriseModules: false,
-    updateColumnState: false,
-    persisted_props: ['selectedRows'],
-    persistence_type: 'local',
-    suppressDragLeaveHidesColumns: true,
-    dangerously_allow_code: false,
-    rowModelType: 'clientSide',
-    dashGridOptions: {},
-    filterModel: {},
-    paginationGoTo: null,
-    selectedRows: [],
-};
 DashAgGrid.propTypes = {
     /********************************
      * DASH PROPS
@@ -751,7 +763,6 @@ DashAgGrid.propTypes = {
 };
 
 export const propTypes = DashAgGrid.propTypes;
-export const defaultProps = DashAgGrid.defaultProps;
 
 export default DashAgGrid;
 

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1342,10 +1342,10 @@ export function DashAgGrid(props) {
 
     // Handle gridApi initialization - column state application
     useEffect(() => {
-        if (gridApi && gridApi !== prevGridApi && props.columnState) {
+        if (gridApi && gridApi !== prevGridApi && columnState_push) {
             setColumnState();
         }
-    }, [gridApi, prevGridApi, props.columnState, setColumnState]);
+    }, [gridApi, prevGridApi, columnState_push]);
 
     // Handle gridApi initialization - finalization
     useEffect(() => {
@@ -1378,7 +1378,7 @@ export function DashAgGrid(props) {
                 setColumnState_push(true);
             }
         }
-    }, [props.columnState, props.loading_state, columnState_push]);
+    }, [props.columnState, props.loading_state]);
 
     // Handle ID changes
     useEffect(() => {

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -1605,11 +1605,9 @@ export function DashAgGrid(props) {
     );
 }
 
-DashAgGrid.defaultProps = _defaultProps;
 DashAgGrid.propTypes = {parentState: PropTypes.any, ..._propTypes};
 
 export const propTypes = DashAgGrid.propTypes;
-export const defaultProps = DashAgGrid.defaultProps;
 
 var dagfuncs = (window.dash_ag_grid = window.dash_ag_grid || {});
 dagfuncs.useGridFilter = useGridFilter;

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -15,10 +15,7 @@ import {
     assoc,
     assocPath,
 } from 'ramda';
-import {
-    propTypes as _propTypes,
-    apiGetters,
-} from '../components/AgGrid.react';
+import {propTypes as _propTypes, apiGetters} from '../components/AgGrid.react';
 import {
     COLUMN_DANGEROUS_FUNCTIONS,
     COLUMN_MAYBE_FUNCTIONS,

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -17,7 +17,6 @@ import {
 } from 'ramda';
 import {
     propTypes as _propTypes,
-    defaultProps as _defaultProps,
     apiGetters,
 } from '../components/AgGrid.react';
 import {

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -321,6 +321,8 @@ export const PASSTHRU_PROPS = ['rowData'];
  */
 export const PROPS_NOT_FOR_AG_GRID = [
     'children',
+    'dashRenderType',
+    'licenseKey',
     'setProps',
     'loading_state',
     'enableEnterpriseModules',
@@ -354,6 +356,7 @@ export const PROPS_NOT_FOR_AG_GRID = [
     'scrollTo',
     'eventListeners',
     'eventData',
+    'paginationInfo',
 ];
 
 /**

--- a/tests/test_column_state.py
+++ b/tests/test_column_state.py
@@ -84,7 +84,7 @@ colState = [
 alt_colState = [
     {
         "colId": "price",
-        "width": 198,
+        "width": 200,
         "hide": False,
         "pinned": None,
         "sort": "asc",
@@ -239,7 +239,7 @@ def test_cs001_column_state(dash_duo):
 
     dash_duo.find_element("#get-column-state-button").click()
     testState = colState.copy()
-    testState[1]["width"] = 198
+    testState[1]["width"] = 200
     until(
         lambda: json.dumps(testState)
         in dash_duo.find_element("#reset-column-state-grid-pre").text,

--- a/tests/test_column_state.py
+++ b/tests/test_column_state.py
@@ -475,28 +475,26 @@ def test_cs003_column_state(dash_duo):
         [
             html.Div(
                 [
-                    html.Button(
-                        "Remove Column", id="remove-column", n_clicks=0
-                    ),
+                    html.Button("Remove Column", id="remove-column", n_clicks=0),
                     html.Div(
-                        id='grid-holder',
+                        id="grid-holder",
                         children=[
                             dag.AgGrid(
                                 id=f"grid",
                                 columnDefs=columnDefs,
                                 rowData=data,
-                                columnSize='autoSize'
+                                columnSize="autoSize",
                             )
-                        ]
-                    )
+                        ],
+                    ),
                 ],
             ),
         ]
     )
 
     @app.callback(
-        Output('grid', 'columnDefs'),
-        Input('remove-column', 'n_clicks'),
+        Output("grid", "columnDefs"),
+        Input("remove-column", "n_clicks"),
     )
     def remove_column(n):
         if n:
@@ -506,13 +504,15 @@ def test_cs003_column_state(dash_duo):
                 return cols
         return no_update
 
-    dash_duo.start_server(app,
-                          debug=True, 
-                          use_reloader=False,
+    dash_duo.start_server(
+        app,
+        debug=True,
+        use_reloader=False,
         use_debugger=True,
         dev_tools_hot_reload=False,
         dev_tools_props_check=True,
-        dev_tools_disable_version_check=True,)
+        dev_tools_disable_version_check=True,
+    )
 
     for x in range(3):
         dash_duo.find_element("#remove-column").click()

--- a/tests/test_column_state.py
+++ b/tests/test_column_state.py
@@ -1,4 +1,4 @@
-from dash import Dash, html, Output, Input, no_update, State, ctx
+from dash import Dash, html, Output, Input, no_update, State, ctx, Patch
 import dash_ag_grid as dag
 import plotly.express as px
 import json
@@ -316,3 +316,205 @@ def test_cs002_column_state(dash_duo):
         dash_duo.find_element("#add-grid").click()
         time.sleep(2)  # pausing to emulate separation because user inputs
     assert list(filter(lambda i: i.get("level") != "WARNING", dash_duo.get_logs())) == []
+
+def test_cs003_column_state(dash_duo):
+    data = [
+        {
+            "localTime": "5:00am",
+            "a": 0.231,
+            "b": 0.523,
+            "c": 0.423,
+            "d": 0.527,
+        },
+        {
+            "localTime": "5:15am",
+            "a": 0.423,
+            "b": 0.452,
+            "c": 0.523,
+            "d": 0.543,
+        },
+        {
+            "localTime": "5:30am",
+            "a": 0.537,
+            "b": 0.246,
+            "c": 0.426,
+            "d": 0.421,
+        },
+        {
+            "localTime": "5:45am",
+            "a": 0.893,
+            "b": 0.083,
+            "c": 0.532,
+            "d": 0.983,
+        },
+        {
+            "localTime": "6:00am",
+            "a": 0.231,
+            "b": 0.523,
+            "c": 0.423,
+            "d": 0.527,
+        },
+        {
+            "localTime": "6:15am",
+            "a": 0.423,
+            "b": 0.452,
+            "c": 0.523,
+            "d": 0.543,
+        },
+        {
+            "localTime": "6:30am",
+            "a": 0.537,
+            "b": 0.246,
+            "c": 0.426,
+            "d": 0.421,
+        },
+        {
+            "localTime": "6:45am",
+            "a": 0.893,
+            "b": 0.083,
+            "c": 0.532,
+            "d": 0.983,
+        },
+        {
+            "localTime": "7:00am",
+            "a": 0.231,
+            "b": 0.523,
+            "c": 0.423,
+            "d": 0.527,
+        },
+        {
+            "localTime": "7:15am",
+            "a": 0.423,
+            "b": 0.452,
+            "c": 0.523,
+            "d": 0.543,
+        },
+        {
+            "localTime": "7:30am",
+            "a": 0.537,
+            "b": 0.246,
+            "c": 0.426,
+            "d": 0.421,
+        },
+        {
+            "localTime": "7:45am",
+            "a": 0.893,
+            "b": 0.083,
+            "c": 0.532,
+            "d": 0.983,
+        },
+        {
+            "localTime": "8:00am",
+            "a": 0.231,
+            "b": 0.523,
+            "c": 0.423,
+            "d": 0.527,
+        },
+        {
+            "localTime": "8:15am",
+            "a": 0.423,
+            "b": 0.452,
+            "c": 0.523,
+            "d": 0.543,
+        },
+        {
+            "localTime": "8:30am",
+            "a": 0.537,
+            "b": 0.246,
+            "c": 0.426,
+            "d": 0.421,
+        },
+        {
+            "localTime": "8:45am",
+            "a": 0.893,
+            "b": 0.083,
+            "c": 0.532,
+            "d": 0.983,
+        },
+        {
+            "localTime": "8:00am",
+            "a": 0.231,
+            "b": 0.523,
+            "c": 0.423,
+            "d": 0.527,
+        },
+        {
+            "localTime": "8:15am",
+            "a": 0.423,
+            "b": 0.452,
+            "c": 0.523,
+            "d": 0.543,
+        },
+        {
+            "localTime": "8:30am",
+            "a": 0.537,
+            "b": 0.246,
+            "c": 0.426,
+            "d": 0.421,
+        },
+        {
+            "localTime": "8:45am",
+            "a": 0.893,
+            "b": 0.083,
+            "c": 0.532,
+            "d": 0.983,
+        },
+    ]
+
+    columnDefs = [
+        {"field": "localTime"},
+        {"field": "a"},
+        {"field": "b"},
+        {"field": "c"},
+        {"field": "d"},
+    ]
+
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.Div(
+                [
+                    html.Button(
+                        "Remove Column", id="remove-column", n_clicks=0
+                    ),
+                    html.Div(
+                        id='grid-holder',
+                        children=[
+                            dag.AgGrid(
+                                id=f"grid",
+                                columnDefs=columnDefs,
+                                rowData=data,
+                                columnSize='autoSize'
+                            )
+                        ]
+                    )
+                ],
+            ),
+        ]
+    )
+
+    @app.callback(
+        Output('grid', 'columnDefs'),
+        Input('remove-column', 'n_clicks'),
+    )
+    def remove_column(n):
+        if n:
+            cols = Patch()
+            if n < 3:
+                del cols[0]
+                return cols
+        return no_update
+
+    dash_duo.start_server(app,
+                          debug=True, 
+                          use_reloader=False,
+        use_debugger=True,
+        dev_tools_hot_reload=False,
+        dev_tools_props_check=True,
+        dev_tools_disable_version_check=True,)
+
+    for x in range(3):
+        dash_duo.find_element("#remove-column").click()
+        time.sleep(2)  # pausing to emulate separation because user inputs
+    assert list(filter(lambda i: i.get("level") != "ERROR", dash_duo.get_logs())) == []


### PR DESCRIPTION
This PR cherry picks v33 changes back to v32:
* [column state bugfix](https://github.com/plotly/dash-ag-grid/pull/400)
* [remove defaultProps](https://github.com/plotly/dash-ag-grid/pull/392)
* fixes test that seems to fail for unrelated reasons (magic number used in test was now incorrect) - would like feedback on this! 46603dd 