### PR TITLE
Add onRowDoubleClicked event

### DIFF
--- a/src/lib/components/AgGrid.react.js
+++ b/src/lib/components/AgGrid.react.js
@@ -703,6 +703,31 @@ DashAgGrid.propTypes = {
     }),
 
     /**
+     * Row is double clicked.
+     */
+    rowDoubleClicked: PropTypes.shape({
+        /**
+         * data object from the double-clicked row
+         */
+        data: PropTypes.any,
+
+        /**
+         * rowIndex, typically a row number
+         */
+        rowIndex: PropTypes.number,
+
+        /**
+         * Row Id from the grid, this could be a number automatically, or set via getRowId
+         */
+        rowId: PropTypes.any,
+
+        /**
+         * timestamp of last action
+         */
+        timestamp: PropTypes.any,
+    }),
+
+    /**
      * The actively selected rows from the grid (may include filtered rows)
      * Can take one of three forms:
      * (1) an array of row objects - if you have defined `getRowId`, you only need the fields it uses.

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -911,6 +911,21 @@ export function DashAgGrid(props) {
         [customSetProps]
     );
 
+    const onRowDoubleClicked = useCallback(
+        ({data, rowIndex, node}) => {
+            const timestamp = Date.now();
+            customSetProps({
+                rowDoubleClicked: {
+                    data,
+                    rowIndex,
+                    rowId: node.id,
+                    timestamp,
+                },
+            });
+        },
+        [customSetProps]
+    );
+
     const onCellValueChanged = useCallback(
         ({oldValue, value, column: {colId}, rowIndex, data, node}) => {
             const timestamp = Date.now();
@@ -1578,6 +1593,7 @@ export function DashAgGrid(props) {
                 onSelectionChanged={onSelectionChanged}
                 onCellClicked={onCellClicked}
                 onCellDoubleClicked={onCellDoubleClicked}
+                onRowDoubleClicked={onRowDoubleClicked}
                 onCellValueChanged={debounce(
                     afterCellValueChanged,
                     CELL_VALUE_CHANGED_DEBOUNCE_MS,


### PR DESCRIPTION
Added `onRowDoubleClicked` event, following example in https://github.com/plotly/dash-ag-grid/pull/201
[AG Grid docs ](https://www.ag-grid.com/javascript-data-grid/grid-events/#reference-selection-rowDoubleClicked)