### PR TITLE
Split publish into separate PyPI and npm workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      python-version: '3.10'
+      node-version: 'v18.16.0'
+
+  npm-publish:
+    name: Upload release to NPM
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+    permissions:
+      id-token: write
+      contents: read
+    needs: build
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Download npm package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: npm-dist/
+      - name: Publish to npm
+        run: |
+          pushd npm-dist
+          FILE=$(echo *.tgz)
+          npm publish "$FILE" --provenance --access public
+          popd
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI & NPM
+name: Publish to PyPI
 
 on:
   release:
@@ -30,22 +30,3 @@ jobs:
           path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        
-      - name: Download npm package
-        uses: actions/download-artifact@v4
-        with:
-          name: npm-package
-          path: npm-dist/
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish to npm
-        run: |
-          pushd npm-dist
-          FILE=$(echo *.tgz)
-          npm publish "$FILE" --provenance --access public
-          popd
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        shell: bash


### PR DESCRIPTION
## Summary
- Replaces `publish.yml` with two separate workflows:
  - `pypi-publish.yml` — publishes to PyPI on release
  - `npm-publish.yml` — publishes to npm on release, and supports manual trigger via `workflow_dispatch`
- No dependencies between the two; they both only need the `build` job artifacts

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Confirm `npm` environment exists in GitHub repo settings
- [ ] Test with a release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)