### PR TITLE
Group agg filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 ## [unreleased]
 
 ### Added
-- [#472](https://github.com/plotly/dash-ag-grid/pull/472) Added support for callback function for the groupAggFiltering options
 - [#453](https://github.com/plotly/dash-ag-grid/pull/453) Test for changelog entry
 - [#448](https://github.com/plotly/dash-ag-grid/pull/448) Added support for AG-Charts (split out in v33 of AG Grid).  Integrated Charts require enableEnterpriseModules=True, dashChartMode="community" or "enterprise", and dashGridOptions={"enableCharts": True}.
 - [#455](https://github.com/plotly/dash-ag-grid/pull/455) Added support for dynamic `detailCellRendererParams` in Master/Detail, including dynamic detail-grid column definitions.
+- [#472](https://github.com/plotly/dash-ag-grid/pull/472) Added support for callback function for the groupAggFiltering options
 
 ### Changed
 - [#452](https://github.com/plotly/dash-ag-grid/pull/452) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 ## [unreleased]
 
 ### Added
+- [#472](https://github.com/plotly/dash-ag-grid/pull/472) Added support for callback function for the groupAggFiltering options
 - [#453](https://github.com/plotly/dash-ag-grid/pull/453) Test for changelog entry
 - [#448](https://github.com/plotly/dash-ag-grid/pull/448) Added support for AG-Charts (split out in v33 of AG Grid).  Integrated Charts require enableEnterpriseModules=True, dashChartMode="community" or "enterprise", and dashGridOptions={"enableCharts": True}.
 - [#455](https://github.com/plotly/dash-ag-grid/pull/455) Added support for dynamic `detailCellRendererParams` in Master/Detail, including dynamic detail-grid column definitions.

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -70,6 +70,7 @@ export const GRID_MAYBE_FUNCTIONS = {
     isExternalFilterPresent: 1,
     doesExternalFilterPass: 1,
     quickFilterParser: 1,
+    groupAggFiltering: 1,
 
     // Integrated Charts
     getChartToolbarItems: 1,

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -387,3 +387,48 @@ def test_fi006_custom_filter(dash_duo):
     apply_buttons = dash_duo.find_elements('button[data-ref="applyFilterButton"]')
     apply_buttons[1].click()
     grid.wait_for_cell_text(0, 2, "24/08/2008")
+    
+    
+def test_fi007_custom_filter(dash_duo):
+
+    app = Dash(__name__)
+    
+    column_defs = [
+        {"field": "country", "rowGroup": True, "hide": True},
+        {"field": "year"},
+        {"field": "total", "aggFunc": "sum", "filter": "agNumberColumnFilter"},
+    ]
+    
+    default_col_def = {
+        "flex": 1,
+        "floatingFilter": True,
+    }
+    
+    auto_group_column_def = {
+        "field": "athlete",
+    }
+    
+    app.layout = html.Div(
+        children=[
+            dag.AgGrid(
+                id="grid",
+                rowData=df.to_dict("records"),
+                columnDefs=column_defs,
+                defaultColDef=default_col_def,
+                dashGridOptions={
+                    "groupAggFiltering": {"function": "!!params.node.group"},
+                    "groupDefaultExpanded": -1,
+                    "autoGroupColumnDef": auto_group_column_def,
+                },
+                enableEnterpriseModules=True,
+            )
+        ],
+    )
+    
+    dash_duo.start_server(app)
+    grid = utils.Grid(dash_duo, "grid")
+    grid.wait_for_cell_text(1, 0, "Michael Phelps")
+
+    grid.set_filter(3, 8)
+    grid.wait_for_cell_text(0, 3, "8")
+    


### PR DESCRIPTION
This pull request is created to close the issue #471.

The modifications in the propCategories.js allow to use the "groupAggFiltering" options in ag grid with a custom callback function and follow the ag-grid behavior described in the documentation https://www.ag-grid.com/javascript-data-grid/aggregation-filtering/#configure-by-callback.

This allows the user to filter only on aggregated results in ag-grid.

A test is added on test_custom_filter.py to validate the new behavior.