### PR TITLE
Fix uncaught TypeError in onSortChanged when grid initializes with a sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Links "DE#nnn" prior to version 2.0 point to the Dash Enterprise closed-source D
 
 ## [unreleased]
 
+### Fixed
+- [#466](https://github.com/plotly/dash-ag-grid/issues/466) fix uncaught TypeError in `onSortChanged` when the grid initializes with a sort in `initialState`
+
 ## [33.3.3] - 2025-12-19
 ### Fixed
 - [#408](https://github.com/plotly/dash-ag-grid/pull/408) fixed issue where the `columnState` would conflict with `columnDefs` updates

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -733,6 +733,9 @@ export function DashAgGrid(props) {
     }, [props.rowData, virtualRowData, getRowData, customSetProps]);
 
     const onSortChanged = useCallback(() => {
+        if (!gridApi) {
+            return;
+        }
         const {rowModelType} = props;
         const propsToSet = {};
         if (rowModelType === 'clientSide') {


### PR DESCRIPTION
Fixes #466

## Problem
When a grid is created with a sort in `dashGridOptions.initialState.sort.sortModel`,
AG Grid fires `sortChanged` from its async event queue during init before the
component's `gridApi` state has been assigned. `onSortChanged` was the only event
handler dereferencing `gridApi` without a null guard, so every such grid logged one
uncaught `TypeError: Cannot read properties of null (reading 'isDestroyed')` on page load.

## Fix
Early-return from `onSortChanged` when `gridApi` is null, matching the existing
pattern in `onFilterChanged`. This also avoids sending a spurious
`virtualRowData=[]` update to Dash during init.

## Verification
Reproduced with a minimal app (3-row grid with an `initialState` sort) on
dash-ag-grid 35.2.0: one uncaught TypeError per page load. After this patch
(rebuilt locally, installed with `pip install -e .`): console is clean and the
grid renders with the initial sort correctly applied.
