### PR TITLE
Fix npm publish: bump Node to 24, pin npm to 11.x

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,12 +24,13 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for trusted publishing
-        # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the
-        # version bundled with Node 20.
-        run: npm install -g npm@latest
+        # Trusted publishing (OIDC) requires npm >= 11.5.1. Pin to the 11.x
+        # line: npm@latest is now 12.x, which requires a newer Node than the
+        # runner provides (EBADENGINE).
+        run: npm install -g npm@11
         shell: bash
       - name: Download npm package
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Why

After switching to trusted publishing (#476), the `v34.3.0` release run failed at the new "Upgrade npm for trusted publishing" step:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now floats to **npm 12**, which requires a newer Node than the job's Node 20. The step errors before publish is ever attempted.

## Fix

- Bump the publish job to **Node 24** (also clears the Node 20 deprecation warning).
- Pin the upgrade to **`npm@11`** instead of `@latest`. The 11.x line satisfies the `npm >= 11.5.1` requirement for trusted publishing and won't drift into an incompatible major.

Targets `v35` (default branch); a matching fix goes to `v34` so the `v34.3.0` release can be republished via `workflow_dispatch`.