### PR TITLE
Fix npm publish: bump Node to 24, pin npm to 11.x (v34)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,12 +24,13 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for trusted publishing
-        # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the
-        # version bundled with Node 20.
-        run: npm install -g npm@latest
+        # Trusted publishing (OIDC) requires npm >= 11.5.1. Pin to the 11.x
+        # line: npm@latest is now 12.x, which requires a newer Node than the
+        # runner provides (EBADENGINE).
+        run: npm install -g npm@11
         shell: bash
       - name: Download npm package
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Why

The `v34.3.0` release run failed at the "Upgrade npm for trusted publishing" step with `EBADENGINE`: `npm install -g npm@latest` now floats to **npm 12**, which requires Node >= 22.22/24.15, but the job runs Node 20.

## Fix

- Bump the publish job to **Node 24** (also clears the Node 20 deprecation warning).
- Pin the upgrade to **`npm@11`** (satisfies the `npm >= 11.5.1` trusted-publishing requirement without drifting into an incompatible major).

Backport of #478 (into `v35`) to the `v34` branch. Once merged, the `v34.3.0` publish can be re-run via `workflow_dispatch`.